### PR TITLE
[Refactor] Advisor agents: require full ToC reading

### DIFF
--- a/templates/agents/rules-advisor.md
+++ b/templates/agents/rules-advisor.md
@@ -11,11 +11,21 @@ Analyze task content and return a list of required development document paths.
 
 ## Procedure
 
-1. Read `.claude/doc-advisor/rules/rules_toc.yaml`
+1. Read `.claude/doc-advisor/rules/rules_toc.yaml` **completely**
+   - **MANDATORY**: Read the entire file with the Read tool. Do NOT use Grep or search tools on ToC
    - **If not found**: Search with Glob `{{RULES_DIR}}/**/*.md` and read each file directly
-2. Match task content against each entry's `applicable_tasks` and `keywords`
+2. Deeply understand all entries, then match task content against each entry's `applicable_tasks` and `keywords`
 3. If there's any chance of relevance, read the actual file to confirm (no false negatives allowed)
 4. Return the confirmed path list
+
+## Critical Rule
+
+**ToC must be fully read and deeply understood before making decisions.**
+
+- ❌ PROHIBITED: Using Grep/search tools on ToC content
+- ❌ PROHIBITED: Partial reading or skimming the ToC
+- ✅ REQUIRED: Read the entire ToC file with Read tool
+- ✅ REQUIRED: Understand all entries before identifying relevant documents
 
 ## Output Format
 

--- a/templates/agents/specs-advisor.md
+++ b/templates/agents/specs-advisor.md
@@ -11,12 +11,22 @@ Analyze task content and return a list of required requirement/design document p
 
 ## Procedure
 
-1. Read `.claude/doc-advisor/specs/specs_toc.yaml` (YAML format index)
-2. Identify relevant candidates from task content
-   - Search `docs` object for entries with `doc_type: requirement` (match by keywords, purpose, title)
-   - Search `docs` object for entries with `doc_type: design` (match by keywords, purpose, title)
+1. Read `.claude/doc-advisor/specs/specs_toc.yaml` **completely** (YAML format index)
+   - **MANDATORY**: Read the entire file with the Read tool. Do NOT use Grep or search tools on ToC
+2. Deeply understand all entries, then identify relevant candidates from task content
+   - Find entries with `doc_type: requirement` (match by keywords, purpose, title)
+   - Find entries with `doc_type: design` (match by keywords, purpose, title)
 3. If there's any chance of relevance, read the actual file to confirm (no false negatives allowed)
 4. Return the confirmed path list
+
+## Critical Rule
+
+**ToC must be fully read and deeply understood before making decisions.**
+
+- ❌ PROHIBITED: Using Grep/search tools on ToC content
+- ❌ PROHIBITED: Partial reading or skimming the ToC
+- ✅ REQUIRED: Read the entire ToC file with Read tool
+- ✅ REQUIRED: Understand all entries before identifying relevant documents
 
 ## Output Format
 


### PR DESCRIPTION
## 概要

- Advisor エージェント（rules-advisor, specs-advisor）に ToC 全文読み込み必須ルールを追加
- ToC を Grep/検索ツールで部分検索することを禁止

## 背景

ToC はドキュメントの検索インデックスであり、全体を理解した上で関連ドキュメントを特定する必要がある。部分的な検索では見落としが発生するリスクがある。

## やったこと

- `templates/agents/rules-advisor.md`: Critical Rule セクション追加
- `templates/agents/specs-advisor.md`: Critical Rule セクション追加
- Read ツールで全文読み込み、深く理解してから判断することを明示

## やらないこと（このプルリクエストのスコープ外とすること）

- スクリプトの変更
- config.yaml の変更

## 画面設計書

N/A

## デザイン仕様書

N/A

## API仕様書

N/A

## レビュー観点

- agent 定義ファイルの記載内容が適切か
- 禁止事項・必須事項の表現が明確か

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- Lv1: ぱっとみて違和感がないかチェックしてAcceptする
- ~~Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする~~
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## スクリーンショット

N/A

## 備考

なし