### PR TITLE
[Refactor] README & TECHNICAL_GUIDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,6 @@ Config file: `.claude/doc-advisor/config.yaml`
 - Japanese: [TECHNICAL_GUIDE_ja.md](TECHNICAL_GUIDE_ja.md)
 - English: [TECHNICAL_GUIDE.md](TECHNICAL_GUIDE.md)
 
-## Private Specs Notice
-
-Some specifications exist only in a private environment. This public README does **not**
-reference their titles or contents because they are not published.
-
 ## Requirements
 
 - Python 3 (standard library only)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Key features:
 - **Parallel processing**: Up to 5 concurrent workers
 - **Interruption recovery**: Preserve completed work and resume
 
+For full details, see [TECHNICAL_GUIDE.md](TECHNICAL_GUIDE.md).
+
 ## Design Intent (Highlights)
 
 - **rules / specs separation**: Reduce search cost and ambiguity
@@ -110,12 +112,10 @@ Config file: `.claude/doc-advisor/config.yaml`
 - Add user-defined exclude patterns as needed
 - System files (`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`) are always excluded
 
-See `TECHNICAL_GUIDE.md` for details.
-
 ## Documentation
 
-- Japanese: `TECHNICAL_GUIDE_ja.md`
-- English: `TECHNICAL_GUIDE.md`
+- Japanese: [TECHNICAL_GUIDE_ja.md](TECHNICAL_GUIDE_ja.md)
+- English: [TECHNICAL_GUIDE.md](TECHNICAL_GUIDE.md)
 
 ## Private Specs Notice
 

--- a/README.md
+++ b/README.md
@@ -1,403 +1,132 @@
 # Doc Advisor (v3.0)
 
-Doc Advisor keeps your AI's context clean by indexing documents and delivering only what's needed.
-
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## Why ToC (Table of Contents)?
+## Introduction
 
-Generative AI has structural limitations:
+Generative AI can miss important specs even when you say “read the docs.”
+Doc Advisor is built on that constraint to ensure the AI reads only what it truly needs.
 
-- **Lost in the Middle**: Information in the "middle" of long contexts gets overlooked
-- **Attention Dilution**: The longer the input, the more attention spreads thin
+## Premise
 
-**Solution**: Don't feed everything—pass only what's needed.
+This project builds on the ideas in:
+[Why generative AI doesn't read documents even when asked — Context Engineering and Doc Advisor](https://zenn.dev/k2moons/articles/ff6399ee33346e)
 
-Doc Advisor pre-indexes your documents and provides only the relevant files for each task.
+Key limitations highlighted there:
 
-## Overview
+- Context Rot: Information in the middle of long contexts is missed
+- Attention Budget: Attention is finite and degrades with excessive input
+- Satisficing: The model stops early with a “good-enough” answer
 
-Doc Advisor helps you manage project documentation by automatically indexing documents and enabling AI agents to quickly identify relevant files for any task.
+## Goals and Features
 
-### Key Features
+Doc Advisor’s goal is to identify the right documents quickly and reliably.
+Key features:
 
-- **Automatic ToC Generation**: Analyzes document content and generates searchable structured indexes
-- **Incremental Updates**: Processes only changed files using SHA-256 hash-based change detection
-- **Parallel Processing**: Up to 5 concurrent subagents for faster document processing
-- **Interruption Recovery**: Preserves completed work and supports resumption
-- **Project-Based Setup**: All files are copied to your project, no plugin mode required
+- **Document categories**: Separate rules and specs
+- **doc_type management**: requirement / design / plan
+- **Automatic ToC generation**: Parse `.md`, extract metadata, output YAML
+- **Incremental updates**: SHA-256 change detection
+- **Parallel processing**: Up to 5 concurrent workers
+- **Interruption recovery**: Preserve completed work and resume
 
-## Document Model
+## Design Intent (Highlights)
 
-Doc Advisor manages two categories of documents: **rule** and **spec**.
+- **rules / specs separation**: Reduce search cost and ambiguity
+- **plan excluded from ToC**: Plans are read in full during work
+- **Path-based doc_type detection**: Stable detection without filename constraints
+- **File path as identifier**: Avoid forced IDs and keep references consistent
+- **Incremental processing**: Only reprocess what changed
+- **Interruption-first**: `.toc_work/` keeps artifacts for safe resumption
 
-| Category | Directory | Purpose | Configurable |
-|----------|-----------|---------|--------------|
-| rule | `rules/` | Development documentation | Yes |
-| spec | `specs/` | Project specifications | Yes |
+## Typical Use Cases
 
-### rule - Development Documentation
+- Large document sets: Retrieve only what matters
+- Frequent updates: Reprocess deltas only
+- Interruptions: Resume from pending entries
+- Deletions: Apply delete-only updates via checksums
+- Parallel failures: Fall back to serial processing
 
-Free-form structure. Any `.md` file in any subdirectory is indexed.
+## Quick Start
 
-| Content Type | Examples |
-|--------------|----------|
-| Architecture rules | `rules/core/architecture.md` |
-| Coding standards | `rules/coding/naming_convention.md` |
-| Workflow guides | `rules/workflow/review_process.md` |
-
-### spec - Project Specifications
-
-The doc_type is automatically determined if the subdirectory name appears anywhere in the path.
-
-| doc_type | Subdirectory | Purpose | Configurable |
-|----------|--------------|---------|--------------|
-| `requirement` | `requirements/` | Functional requirements, use cases | Yes |
-| `design` | `design/` | Technical design, architecture decisions | Yes |
-| `plan` | `plan/` | Project plans (definition only, not indexed in ToC) | - |
-
-Examples:
-- `specs/requirements/login.md` → requirement
-- `specs/main/design/architecture.md` → design
-- `specs/auth/oauth/requirements/api.md` → requirement
-
-### How ToC Generation Works
-
-#### Search Scope
-
-The system recursively searches under `specs/` and targets files whose path contains a `requirement` or `design` directory. There is no depth limit.
-
-| Path Example | Included | Reason |
-|--------------|----------|--------|
-| `specs/feature1/requirements/app.md` | ✅ | Contains `requirements` |
-| `specs/main/sub/design/api.md` | ✅ | Contains `design` |
-| `specs/feature1/plan/task.md` | ❌ | Not included |
-
-#### Why plan is Excluded
-
-The `plan` directory is excluded from ToC indexing:
-
-1. **Read in full during work**: Plans are read entirely at execution time, so partial search indexing is unnecessary
-2. **Pre-defined execution plans**: requirement/design are "what to build" references; plan is the "how to build" execution plan
-
-#### Processing Time
-
-| Process | Executor | Speed |
-|---------|----------|-------|
-| Recursive search | Python (`rglob`) | Fast |
-| Change detection | Python (SHA-256) | Fast |
-| Content analysis | Claude (LLM) | **Slow** |
-| Merge | Python | Fast |
-
-The bottleneck is LLM content analysis. Incremental mode (default) optimizes by processing only changed files.
-
-## Installation
-
-### 1. Clone the repository
+1) Clone the repository
 
 ```bash
 git clone https://github.com/BlueEventHorizon/DocAdvisor-CC.git
 ```
 
-### 2. Setup target project
-
-Run `setup.sh` with your target project path:
+2) Run setup for your target project
 
 ```bash
 cd DocAdvisor-CC
 ./setup.sh /path/to/your-project
 ```
 
-This copies all necessary files to your project:
-```
-your-project/.claude/
-├── commands/          # Command files
-├── agents/            # Agent definitions
-├── skills/            # Skill modules
-└── doc-advisor/
-    └── config.yaml    # Project configuration
-```
-
-Setup will interactively ask for:
-- Rules directory (default: `rules/`)
-- Specs directory (default: `specs/`)
-- Requirements subdirectory name (default: `requirements`)
-- Design subdirectory name (default: `design`)
-
-### 3. Launch Claude Code
+3) Launch Claude Code
 
 ```bash
 cd /path/to/your-project
 claude
 ```
 
-No `--plugin-dir` flag needed! All files are already in your project.
-
-### Using Makefile (Alternative)
+4) Generate initial ToC files
 
 ```bash
-cd DocAdvisor-CC
-make setup                            # Interactive mode
-make setup TARGET=/path/to/your-project  # Specify target
+/create-rules_toc --full
+/create-specs_toc --full
 ```
+
+> Using the Makefile:
+>
+> ```bash
+> make setup
+> make setup TARGET=/path/to/your-project
+> ```
 
 ## Usage
 
-### ToC Generation Commands
+### ToC generation commands
 
 ```bash
-# Development documentation (rules/)
-/create-rules_toc          # Incremental update (changed files only)
+/create-rules_toc          # Incremental update
 /create-rules_toc --full   # Full rebuild
 
-# Requirements/design documents (specs/)
 /create-specs_toc          # Incremental update
 /create-specs_toc --full   # Full rebuild
 ```
 
-### Advisor Agents
-
-Automatically identify documents needed for a task:
+### Advisor agents
 
 ```
-Task(subagent_type: rules-advisor, prompt: "Identify documents for implementing user authentication")
+Task(subagent_type: rules-advisor, prompt: "Identify documents for implementing authentication")
 Task(subagent_type: specs-advisor, prompt: "Find requirements for screen navigation")
-```
-
-### Recommended CLAUDE.md Entry
-
-Add the following to your project's `CLAUDE.md` to make Claude automatically reference documents:
-
-```markdown
-## Task Execution Flow [MANDATORY]
-
-When receiving a work task, follow this flow:
-
-1. Identify rule documents with rules-advisor Subagent
-   ```
-   Task(subagent_type: rules-advisor, prompt: [task description])
-   ```
-
-2. Identify requirements/design documents with specs-advisor Subagent
-   ```
-   Task(subagent_type: specs-advisor, prompt: [task description])
-   ```
-
-3. Read **all** required documents (or pass to Subagent)
-
-4. Execute the task
-```
-
-## Architecture
-
-### Configuration File
-
-The scripts use the following configuration file:
-
-- `.claude/doc-advisor/config.yaml`
-
-### ToC Generation Flow
-
-```
-/create-*_toc
-        |
-        v
-+-------------------------------------+
-| 1. Detect changes (SHA-256 hash)    |
-|    Compare checksums -> changed only |
-+------------------+------------------+
-                   |
-                   v
-+-------------------------------------+
-| 2. Parallel processing (max 5)      |
-|    *-toc-updater agents             |
-|    Each agent: read .md -> write YAML|
-+------------------+------------------+
-                   |
-                   v
-+-------------------------------------+
-| 3. Merge & Validate -> *_toc.yaml   |
-+-------------------------------------+
-```
-
-### Advisor Flow
-
-```
-Task(subagent_type: *-advisor)
-        |
-        v
-+-------------------+     +-------------------+
-| Read *_toc.yaml   |---->| Find relevant     |----> Return file paths
-|                   |     | documents         |
-+-------------------+     +-------------------+
-```
-
-## Directory Structure
-
-### Template Repository
-
-```
-DocAdvisor-CC/
-├── templates/
-│   ├── commands/               # Command templates
-│   │   ├── create-rules_toc.md
-│   │   └── create-specs_toc.md
-│   ├── agents/                 # Agent templates
-│   │   ├── rules-advisor.md
-│   │   ├── specs-advisor.md
-│   │   ├── rules-toc-updater.md
-│   │   └── specs-toc-updater.md
-│   ├── skills/                 # Skill templates
-│   │   └── doc-advisor/        # ToC generation scripts
-│   └── doc-advisor/
-│       └── docs/               # ToC format/workflow documentation
-├── setup.sh                    # Project setup script
-├── Makefile                    # Build automation
-└── README.md
-```
-
-### Target Project Structure (after setup)
-
-```
-your-project/
-├── .claude/
-│   ├── commands/
-│   │   ├── create-rules_toc.md
-│   │   └── create-specs_toc.md
-│   ├── agents/
-│   │   ├── rules-advisor.md
-│   │   ├── specs-advisor.md
-│   │   ├── rules-toc-updater.md
-│   │   └── specs-toc-updater.md
-│   ├── skills/
-│   │   └── doc-advisor/        # ToC generation scripts
-│   └── doc-advisor/
-│       ├── config.yaml
-│       ├── docs/               # ToC format/workflow documentation
-│       ├── rules/              # Generated artifacts for rules
-│       │   ├── rules_toc.yaml
-│       │   ├── .toc_checksums.yaml
-│       │   └── .toc_work/
-│       └── specs/              # Generated artifacts for specs
-│           ├── specs_toc.yaml
-│           ├── .toc_checksums.yaml
-│           └── .toc_work/
-├── rules/                      # Rules documentation (configurable)
-│   └── *.md                    # Documentation files
-└── specs/                      # Specs documentation (configurable)
-    ├── requirements/           # Requirement documents
-    └── design/                 # Design documents
 ```
 
 ## Configuration
 
-### Project Configuration
+Config file: `.claude/doc-advisor/config.yaml`
 
-Located at `.claude/doc-advisor/config.yaml`:
+- Customize `rules` / `specs` root directories and doc_type directory names
+- Add user-defined exclude patterns as needed
+- System files (`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`) are always excluded
 
-```yaml
-# === rules configuration ===
-rules:
-  root_dir: rules
-  toc_file: .claude/doc-advisor/rules/rules_toc.yaml
-  checksums_file: .claude/doc-advisor/rules/.toc_checksums.yaml
-  work_dir: .claude/doc-advisor/rules/.toc_work/
+See `TECHNICAL_GUIDE.md` for details.
 
-  patterns:
-    target_glob: "**/*.md"
-    exclude:
-      # - reference    # Uncomment to exclude
-      # - archive
+## Documentation
 
-  output:
-    header_comment: "Development documentation search index for rules-advisor subagent"
-    metadata_name: "Development Documentation Search Index"
+- Japanese: `TECHNICAL_GUIDE_ja.md`
+- English: `TECHNICAL_GUIDE.md`
 
-# === specs configuration ===
-specs:
-  root_dir: specs
-  toc_file: .claude/doc-advisor/specs/specs_toc.yaml
-  checksums_file: .claude/doc-advisor/specs/.toc_checksums.yaml
-  work_dir: .claude/doc-advisor/specs/.toc_work/
+## Private Specs Notice
 
-  patterns:
-    target_dirs:
-      requirement: requirements
-      design: design
-    exclude:
-      - plan           # Read in full during work, no search needed
-      # - reference
-      # - /info/
-
-  output:
-    header_comment: "Requirements and design document search index for specs-advisor subagent"
-    metadata_name: "Requirements and Design Document Search Index"
-
-# === common configuration ===
-common:
-  parallel:
-    max_workers: 5
-    fallback_to_serial: true
-```
-
-> **Note**: System files (`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`) are automatically excluded and do not need to be listed in config.
-
-### Customizing Configuration
-
-Edit the project config file directly, or re-run setup:
-
-```bash
-# Re-run setup interactively
-./setup.sh /path/to/your-project
-
-# Or edit directly
-nano /path/to/your-project/.claude/doc-advisor/config.yaml
-```
-
-## Processing Modes
-
-| Mode | Description |
-|------|-------------|
-| full | Scan all files and regenerate ToC |
-| incremental | Process only changed files (SHA-256 hash detection) |
-| continuation | Resume interrupted processing |
+Some specifications exist only in a private environment. This public README does **not**
+reference their titles or contents because they are not published.
 
 ## Requirements
 
 - Python 3 (standard library only)
 - Claude Code
 - Bash shell
-
-## Troubleshooting
-
-### Config not found error
-
-Ensure you've run setup for your project:
-```bash
-./setup.sh /path/to/your-project
-```
-
-### Commands not recognized
-
-Verify the files exist:
-```bash
-ls -la /path/to/your-project/.claude/commands/
-ls -la /path/to/your-project/.claude/agents/
-```
-
-### ToC generation fails
-
-1. Check if target directories exist in your project
-2. Verify config paths are correct
-3. Look for `.claude/doc-advisor/{rules,specs}/.toc_work/` for recovery
-
-## Migration from v2.0 (Plugin Mode)
-
-If you were using the plugin mode (`--plugin-dir`), follow these steps:
-
-1. Run setup.sh on your project to install the new files
-2. Remove the `--plugin-dir` flag when starting Claude Code
-3. Your existing `config.yaml` in `.claude/doc-advisor/` will be preserved
 
 ## License
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -115,11 +115,6 @@ Task(subagent_type: specs-advisor, prompt: "画面遷移の要件を特定")
 - 日本語: [TECHNICAL_GUIDE_ja.md](TECHNICAL_GUIDE_ja.md)
 - 英語: [TECHNICAL_GUIDE.md](TECHNICAL_GUIDE.md)
 
-## 非公開仕様について
-
-非公開の仕様書は別環境に存在します。公開版の README では、
-それらの**タイトルや内容を参照しません**（非公開のため）。
-
 ## 必要要件
 
 - Python 3（標準ライブラリのみ）

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,404 +1,130 @@
 # Doc Advisor (v3.0)
 
-Doc Advisorは、生成AIのコンテキストをクリーンに保つため、ドキュメントをインデックス化し、生成AIに必要なドキュメントのみを精選して渡します。
-
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## なぜ ToC（目次）が必要か
+## はじめに
 
-生成AIには構造的な限界があります：
+生成AIに「ドキュメントを読んで」と指示しても、重要な仕様を見落とすことがあります。
+Doc Advisor は、この構造的な限界を前提に「必要な文書だけを確実に読ませる」ための運用を実現する仕組みです。
 
-- **Lost in the Middle**: 長いコンテキストの「真ん中」の情報は見落とされる
-- **Attention Dilution**: 入力が長いほど各トークンへの注意が希薄化
+## 前提
 
-**解決策**: 「全部読ませる」のではなく「必要なものだけ渡す」
+[なぜ生成AIは「ドキュメントを読んで」と言っても読まないのか？ ― コンテキスト・エンジニアリングと Doc Advisor](https://zenn.dev/k2moons/articles/ff6399ee33346e) の問題意識を土台にしています。
+指摘されている主な制約は次の通りです。
 
-Doc Advisor は、ドキュメントを事前にインデックス化し、タスクに必要なファイルだけをAIに渡します。
+- Context Rot: 長い文脈ほど「真ん中」の情報が読まれにくい
+- Attention Budget: 注意資源は有限であり、情報過多で精度が落ちる
+- Satisficing: 探索を十分に行わず「それっぽい答え」で止まる
 
-## 概要
+## Doc Advisor の目的と機能
 
-Doc Advisor は、プロジェクトのドキュメントを自動的にインデックス化し、AI エージェントが必要な文書を素早く特定できるようにするツールです。
+Doc Advisor の目的は「必要な文書を、短時間で、確実に特定できるようにすること」です。
+主な機能は次の通りです。
 
-### 主な機能
+- **ドキュメント分類**: rules と specs を分離
+- **doc_type 管理**: requirement / design / plan
+- **ToC 自動生成**: `.md` を解析してメタデータを抽出し YAML 化
+- **差分更新**: SHA-256 で変更検出
+- **並列処理**: 最大 5 並列
+- **中断耐性**: 完了分を保持し再開可能
 
-- **自動 ToC 生成**: ドキュメントの内容を分析し、検索可能な構造化インデックスを自動生成
-- **差分更新**: SHA-256 ハッシュで変更を検出し、変更されたファイルのみを処理
-- **並列処理**: 最大5並列でドキュメント処理を高速化
-- **中断耐性**: 処理中断時も完了分は保持、再開可能
-- **プロジェクトベースのセットアップ**: すべてのファイルがプロジェクトにコピーされ、プラグインモード不要
+## 設計の意図（要点）
 
-## ドキュメントモデル
+- **rules / specs の分離**: 開発ドキュメントと仕様書を明確に分け、参照コストを下げる
+- **plan の除外**: plan は作業時に全文読み込みする前提のため、ToC から外す
+- **パスによる doc_type 判定**: ファイル名の命名自由度を保ちつつ判定を安定化
+- **ファイルパスの識別子化**: 余分なID強制を避け、参照を一貫させる
+- **差分更新**: 変更分のみ処理して運用負荷を削減
+- **中断前提**: `.toc_work/` に成果物を保持し、途中から再開できる
 
-Doc Advisor は **rule** と **spec** の2つのカテゴリのドキュメントを管理します。
+## 想定ケース
 
-| カテゴリ | ディレクトリ | 用途 | 設定可能 |
-|----------|--------------|------|----------|
-| rule | `rules/` | 開発ドキュメント | Yes |
-| spec | `specs/` | プロジェクト仕様 | Yes |
+- 大量ドキュメント: 必要文書だけを検索で抽出
+- 頻繁な更新: 変更分のみ再処理
+- 途中中断: 未完了のみ再開
+- 削除反映: チェックサム差分で delete-only
+- 並列失敗: 直列フォールバックで継続
 
-### rule - 開発ドキュメント
+## クイックスタート
 
-自由形式の構造。任意のサブディレクトリ内の `.md` ファイルがインデックス化されます。
-
-| コンテンツ種別 | 例 |
-|----------------|-----|
-| アーキテクチャルール | `rules/core/architecture.md` |
-| コーディング規約 | `rules/coding/naming_convention.md` |
-| ワークフローガイド | `rules/workflow/review_process.md` |
-
-### spec - プロジェクト仕様
-
-パス内にサブディレクトリ名が含まれていれば、自動的に doc_type が判定されます。
-
-| doc_type | サブディレクトリ | 目的 | 設定可能 |
-|----------|------------------|------|----------|
-| `requirement` | `requirements/` | 機能要件、ユースケース | Yes |
-| `design` | `design/` | 技術設計、アーキテクチャ決定 | Yes |
-| `plan` | `plan/` | プロジェクト計画（定義のみ、ToC対象外） | - |
-
-例:
-- `specs/requirements/login.md` → requirement
-- `specs/main/design/architecture.md` → design
-- `specs/auth/oauth/requirements/api.md` → requirement
-
-### ToC 生成の仕組み
-
-#### 探索範囲
-
-`specs/` 配下を再帰的に探索し、パスに `requirement` または `design` ディレクトリが含まれるファイルを対象とします。深さ制限はありません。
-
-| パス例 | 対象 | 理由 |
-|--------|------|------|
-| `specs/feature1/requirements/app.md` | ✅ | `requirements` を含む |
-| `specs/main/sub/design/api.md` | ✅ | `design` を含む |
-| `specs/feature1/plan/task.md` | ❌ | 対象外 |
-
-#### plan が対象外の理由
-
-`plan` ディレクトリは ToC の対象外です。理由：
-
-1. **作業中に全文読む**: plan は実行時に全文参照するため、検索インデックスによる部分参照は不要
-2. **定義済みの実行計画**: requirement/design は「何を作るか」の参照用、plan は「どう作るか」の定義済み実行計画
-
-#### 処理時間
-
-| 処理 | 実行者 | 速度 |
-|------|--------|------|
-| 再帰探索 | Python (`rglob`) | 高速 |
-| 差分検出 | Python (SHA-256) | 高速 |
-| 内容解析 | Claude (LLM) | **遅い** |
-| 統合 | Python | 高速 |
-
-ボトルネックは LLM による解析です。インクリメンタルモード（デフォルト）では変更ファイルのみ処理することで最適化しています。
-
-## インストール
-
-### 1. リポジトリをクローン
+1) リポジトリをクローン
 
 ```bash
 git clone https://github.com/BlueEventHorizon/DocAdvisor-CC.git
 ```
 
-### 2. ターゲットプロジェクトをセットアップ
-
-`setup.sh` をターゲットプロジェクトのパスで実行：
+2) ターゲットプロジェクトにセットアップ
 
 ```bash
 cd DocAdvisor-CC
 ./setup.sh /path/to/your-project
 ```
 
-これにより、必要なファイルがプロジェクトにコピーされます：
-```
-your-project/.claude/
-├── commands/          # コマンドファイル
-├── agents/            # エージェント定義
-├── skills/            # スキルモジュール
-└── doc-advisor/
-    ├── config.yaml    # プロジェクト設定
-    └── docs/          # ToC フォーマット/ワークフロー文書
-```
-
-セットアップは対話形式で以下を聞いてきます：
-- Rules ディレクトリ（デフォルト: `rules/`）
-- Specs ディレクトリ（デフォルト: `specs/`）
-- Requirements サブディレクトリ名（デフォルト: `requirements`）
-- Design サブディレクトリ名（デフォルト: `design`）
-
-### 3. Claude Code を起動
+3) Claude Code を起動
 
 ```bash
 cd /path/to/your-project
 claude
 ```
 
-`--plugin-dir` フラグは不要です！すべてのファイルは既にプロジェクト内にあります。
-
-### Makefile を使用（代替方法）
+4) 初回 ToC 生成
 
 ```bash
-cd DocAdvisor-CC
-make setup                            # 対話モード
-make setup TARGET=/path/to/your-project  # ターゲット指定
+/create-rules_toc --full
+/create-specs_toc --full
 ```
+
+> Makefile を使う場合:
+>
+> ```bash
+> make setup
+> make setup TARGET=/path/to/your-project
+> ```
 
 ## 使い方
 
 ### ToC 生成コマンド
 
 ```bash
-# 開発ドキュメント（rules/）の ToC 生成
-/create-rules_toc          # 差分更新（変更ファイルのみ処理）
-/create-rules_toc --full   # 全ファイル再生成
+/create-rules_toc          # 差分更新
+/create-rules_toc --full   # 全件再生成
 
-# 要件定義書・設計書（specs/）の ToC 生成
 /create-specs_toc          # 差分更新
-/create-specs_toc --full   # 全ファイル再生成
+/create-specs_toc --full   # 全件再生成
 ```
 
 ### Advisor エージェント
 
-タスクに必要なドキュメントを自動特定：
-
 ```
-Task(subagent_type: rules-advisor, prompt: "ユーザー認証機能の実装に必要な文書を特定")
-Task(subagent_type: specs-advisor, prompt: "画面遷移に関する要件定義書を特定")
-```
-
-### CLAUDE.md への推奨記載
-
-プロジェクトの `CLAUDE.md` に以下を追記すると、Claude が自動的にドキュメントを参照するようになります：
-
-```markdown
-## 作業タスク実施の基本フロー [MANDATORY]
-
-作業タスクを受け取ったら、以下のフローに従うこと：
-
-1. rules-advisor Subagent でルール文書を特定
-   ```
-   Task(subagent_type: rules-advisor, prompt: [タスク内容])
-   ```
-
-2. specs-advisor Subagent で要件定義書・設計書を特定
-   ```
-   Task(subagent_type: specs-advisor, prompt: [タスク内容])
-   ```
-
-3. 必要となる文書セット**全て**を読む（または Subagent に渡す）
-
-4. 作業タスクを実行
-```
-
-## アーキテクチャ
-
-### 設定ファイル
-
-スクリプトは以下の設定ファイルを使用します：
-
-- `.claude/doc-advisor/config.yaml`
-
-### ToC 生成フロー
-
-```
-/create-*_toc
-        |
-        v
-+-------------------------------------+
-| 1. 変更検出 (SHA-256 ハッシュ)      |
-|    チェックサム比較 → 変更分のみ    |
-+------------------+------------------+
-                   |
-                   v
-+-------------------------------------+
-| 2. 並列処理 (最大5並列)             |
-|    *-toc-updater agents             |
-|    各エージェント: .md読込 → YAML出力|
-+------------------+------------------+
-                   |
-                   v
-+-------------------------------------+
-| 3. マージ & 検証 → *_toc.yaml       |
-+-------------------------------------+
-```
-
-### Advisor フロー
-
-```
-Task(subagent_type: *-advisor)
-        |
-        v
-+-------------------+     +-------------------+
-| *_toc.yaml 読込   |---->| 関連ドキュメント  |----> ファイルパス返却
-|                   |     | 検索              |
-+-------------------+     +-------------------+
-```
-
-## ディレクトリ構造
-
-### テンプレートリポジトリ
-
-```
-DocAdvisor-CC/
-├── templates/
-│   ├── commands/               # コマンドテンプレート
-│   │   ├── create-rules_toc.md
-│   │   └── create-specs_toc.md
-│   ├── agents/                 # エージェントテンプレート
-│   │   ├── rules-advisor.md
-│   │   ├── specs-advisor.md
-│   │   ├── rules-toc-updater.md
-│   │   └── specs-toc-updater.md
-│   ├── skills/                 # スキルテンプレート
-│   │   └── doc-advisor/        # ToC 生成スクリプト
-│   └── doc-advisor/
-│       └── docs/               # ToC フォーマット/ワークフロー文書
-├── setup.sh                    # プロジェクトセットアップスクリプト
-├── Makefile                    # ビルド自動化
-└── README.md
-```
-
-### ターゲットプロジェクト構造（セットアップ後）
-
-```
-your-project/
-├── .claude/
-│   ├── commands/
-│   │   ├── create-rules_toc.md
-│   │   └── create-specs_toc.md
-│   ├── agents/
-│   │   ├── rules-advisor.md
-│   │   ├── specs-advisor.md
-│   │   ├── rules-toc-updater.md
-│   │   └── specs-toc-updater.md
-│   ├── skills/
-│   │   └── doc-advisor/        # ToC 生成スクリプト
-│   └── doc-advisor/
-│       ├── config.yaml
-│       ├── docs/               # ToC フォーマット/ワークフロー文書
-│       ├── rules/              # rules の生成成果物
-│       │   ├── rules_toc.yaml
-│       │   ├── .toc_checksums.yaml
-│       │   └── .toc_work/
-│       └── specs/              # specs の生成成果物
-│           ├── specs_toc.yaml
-│           ├── .toc_checksums.yaml
-│           └── .toc_work/
-├── rules/                      # Rules ドキュメント（設定可能）
-│   └── *.md                    # ドキュメントファイル
-└── specs/                      # Specs ドキュメント（設定可能）
-    ├── requirements/           # 要件定義書
-    └── design/                 # 設計書
+Task(subagent_type: rules-advisor, prompt: "認証機能の実装に必要な文書を特定")
+Task(subagent_type: specs-advisor, prompt: "画面遷移の要件を特定")
 ```
 
 ## 設定
 
-### プロジェクト設定
+設定ファイル: `.claude/doc-advisor/config.yaml`
 
-`.claude/doc-advisor/config.yaml` にあります：
+- `rules` / `specs` のルートディレクトリや doc_type ディレクトリ名を変更可能
+- 除外パターンはユーザー定義で追加可能
+- システムファイル（`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`）は自動除外
 
-```yaml
-# === rules 設定 ===
-rules:
-  root_dir: rules
-  toc_file: .claude/doc-advisor/rules/rules_toc.yaml
-  checksums_file: .claude/doc-advisor/rules/.toc_checksums.yaml
-  work_dir: .claude/doc-advisor/rules/.toc_work/
+詳細は `TECHNICAL_GUIDE_ja.md` を参照してください。
 
-  patterns:
-    target_glob: "**/*.md"
-    exclude:
-      # - reference    # 必要に応じてコメント解除
-      # - archive
+## ドキュメント
 
-  output:
-    header_comment: "Development documentation search index for rules-advisor subagent"
-    metadata_name: "Development Documentation Search Index"
+- 日本語: `TECHNICAL_GUIDE_ja.md`
+- 英語: `TECHNICAL_GUIDE.md`
 
-# === specs 設定 ===
-specs:
-  root_dir: specs
-  toc_file: .claude/doc-advisor/specs/specs_toc.yaml
-  checksums_file: .claude/doc-advisor/specs/.toc_checksums.yaml
-  work_dir: .claude/doc-advisor/specs/.toc_work/
+## 非公開仕様について
 
-  patterns:
-    target_dirs:
-      requirement: requirements
-      design: design
-    exclude:
-      - plan           # 作業中に全文読むため、検索不要
-      # - reference
-      # - /info/
-
-  output:
-    header_comment: "Requirements and design document search index for specs-advisor subagent"
-    metadata_name: "Requirements and Design Document Search Index"
-
-# === 共通設定 ===
-common:
-  parallel:
-    max_workers: 5
-    fallback_to_serial: true
-```
-
-> **注**: システムファイル（`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`）は自動的に除外されるため、設定に記載する必要はありません。
-
-### 設定のカスタマイズ
-
-プロジェクト設定ファイルを直接編集するか、セットアップを再実行：
-
-```bash
-# 対話形式で再セットアップ
-./setup.sh /path/to/your-project
-
-# または直接編集
-nano /path/to/your-project/.claude/doc-advisor/config.yaml
-```
-
-## 処理モード
-
-| モード | 説明 |
-|--------|------|
-| full | 全ファイルをスキャンして ToC を再生成 |
-| incremental | 変更ファイルのみ処理（SHA-256 ハッシュで検出） |
-| 継続 | 中断された処理を再開 |
+非公開の仕様書は別環境に存在します。公開版の README では、
+それらの**タイトルや内容を参照しません**（非公開のため）。
 
 ## 必要要件
 
 - Python 3（標準ライブラリのみ）
 - Claude Code
 - Bash シェル
-
-## トラブルシューティング
-
-### 設定が見つからないエラー
-
-プロジェクトのセットアップを実行したか確認：
-```bash
-./setup.sh /path/to/your-project
-```
-
-### コマンドが認識されない
-
-ファイルが存在するか確認：
-```bash
-ls -la /path/to/your-project/.claude/commands/
-ls -la /path/to/your-project/.claude/agents/
-```
-
-### ToC 生成が失敗する
-
-1. ターゲットディレクトリがプロジェクトに存在するか確認
-2. 設定のパスが正しいか確認
-3. `.claude/doc-advisor/{rules,specs}/.toc_work/` で復旧を確認
-
-## v2.0（プラグインモード）からの移行
-
-プラグインモード（`--plugin-dir`）を使用していた場合：
-
-1. プロジェクトで setup.sh を実行して新しいファイルをインストール
-2. Claude Code 起動時に `--plugin-dir` フラグを削除
-3. `.claude/doc-advisor/` 内の既存の `config.yaml` は保持されます
 
 ## ライセンス
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,6 +28,8 @@ Doc Advisor の目的は「必要な文書を、短時間で、確実に特定�
 - **並列処理**: 最大 5 並列
 - **中断耐性**: 完了分を保持し再開可能
 
+詳細は [TECHNICAL_GUIDE_ja.md](TECHNICAL_GUIDE_ja.md) を参照してください。
+
 ## 設計の意図（要点）
 
 - **rules / specs の分離**: 開発ドキュメントと仕様書を明確に分け、参照コストを下げる
@@ -108,12 +110,10 @@ Task(subagent_type: specs-advisor, prompt: "画面遷移の要件を特定")
 - 除外パターンはユーザー定義で追加可能
 - システムファイル（`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`）は自動除外
 
-詳細は `TECHNICAL_GUIDE_ja.md` を参照してください。
-
 ## ドキュメント
 
-- 日本語: `TECHNICAL_GUIDE_ja.md`
-- 英語: `TECHNICAL_GUIDE.md`
+- 日本語: [TECHNICAL_GUIDE_ja.md](TECHNICAL_GUIDE_ja.md)
+- 英語: [TECHNICAL_GUIDE.md](TECHNICAL_GUIDE.md)
 
 ## 非公開仕様について
 

--- a/TECHNICAL_GUIDE.md
+++ b/TECHNICAL_GUIDE.md
@@ -1,0 +1,404 @@
+# Doc Advisor (v3.0)
+
+[![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Doc Advisor keeps your AI's context clean by indexing documents and delivering only what's needed.
+
+## Why ToC (Table of Contents)?
+
+Generative AI has structural limitations:
+
+- **Lost in the Middle**: Information in the "middle" of long contexts gets overlooked
+- **Attention Dilution**: The longer the input, the more attention spreads thin
+
+**Solution**: Don't feed everything—pass only what's needed.
+
+Doc Advisor pre-indexes your documents and provides only the relevant files for each task.
+
+## Overview
+
+Doc Advisor helps you manage project documentation by automatically indexing documents and enabling AI agents to quickly identify relevant files for any task.
+
+### Key Features
+
+- **Automatic ToC Generation**: Analyzes document content and generates searchable structured indexes
+- **Incremental Updates**: Processes only changed files using SHA-256 hash-based change detection
+- **Parallel Processing**: Up to 5 concurrent subagents for faster document processing
+- **Interruption Recovery**: Preserves completed work and supports resumption
+- **Project-Based Setup**: All files are copied to your project, no plugin mode required
+
+## Document Model
+
+Doc Advisor manages two categories of documents: **rule** and **spec**.
+
+| Category | Directory | Purpose | Configurable |
+|----------|-----------|---------|--------------|
+| rule | `rules/` | Development documentation | Yes |
+| spec | `specs/` | Project specifications | Yes |
+
+### rule - Development Documentation
+
+Free-form structure. Any `.md` file in any subdirectory is indexed.
+
+| Content Type | Examples |
+|--------------|----------|
+| Architecture rules | `rules/core/architecture.md` |
+| Coding standards | `rules/coding/naming_convention.md` |
+| Workflow guides | `rules/workflow/review_process.md` |
+
+### spec - Project Specifications
+
+The doc_type is automatically determined if the subdirectory name appears anywhere in the path.
+
+| doc_type | Subdirectory | Purpose | Configurable |
+|----------|--------------|---------|--------------|
+| `requirement` | `requirements/` | Functional requirements, use cases | Yes |
+| `design` | `design/` | Technical design, architecture decisions | Yes |
+| `plan` | `plan/` | Project plans (definition only, not indexed in ToC) | - |
+
+Examples:
+- `specs/requirements/login.md` → requirement
+- `specs/main/design/architecture.md` → design
+- `specs/auth/oauth/requirements/api.md` → requirement
+
+### How ToC Generation Works
+
+#### Search Scope
+
+The system recursively searches under `specs/` and targets files whose path contains a `requirement` or `design` directory. There is no depth limit.
+
+| Path Example | Included | Reason |
+|--------------|----------|--------|
+| `specs/feature1/requirements/app.md` | ✅ | Contains `requirements` |
+| `specs/main/sub/design/api.md` | ✅ | Contains `design` |
+| `specs/feature1/plan/task.md` | ❌ | Not included |
+
+#### Why plan is Excluded
+
+The `plan` directory is excluded from ToC indexing:
+
+1. **Read in full during work**: Plans are read entirely at execution time, so partial search indexing is unnecessary
+2. **Pre-defined execution plans**: requirement/design are "what to build" references; plan is the "how to build" execution plan
+
+#### Processing Time
+
+| Process | Executor | Speed |
+|---------|----------|-------|
+| Recursive search | Python (`rglob`) | Fast |
+| Change detection | Python (SHA-256) | Fast |
+| Content analysis | Claude (LLM) | **Slow** |
+| Merge | Python | Fast |
+
+The bottleneck is LLM content analysis. Incremental mode (default) optimizes by processing only changed files.
+
+## Installation
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/BlueEventHorizon/DocAdvisor-CC.git
+```
+
+### 2. Setup target project
+
+Run `setup.sh` with your target project path:
+
+```bash
+cd DocAdvisor-CC
+./setup.sh /path/to/your-project
+```
+
+This copies all necessary files to your project:
+```
+your-project/.claude/
+├── commands/          # Command files
+├── agents/            # Agent definitions
+├── skills/            # Skill modules
+└── doc-advisor/
+    └── config.yaml    # Project configuration
+```
+
+Setup will interactively ask for:
+- Rules directory (default: `rules/`)
+- Specs directory (default: `specs/`)
+- Requirements subdirectory name (default: `requirements`)
+- Design subdirectory name (default: `design`)
+
+### 3. Launch Claude Code
+
+```bash
+cd /path/to/your-project
+claude
+```
+
+No `--plugin-dir` flag needed! All files are already in your project.
+
+### Using Makefile (Alternative)
+
+```bash
+cd DocAdvisor-CC
+make setup                            # Interactive mode
+make setup TARGET=/path/to/your-project  # Specify target
+```
+
+## Usage
+
+### ToC Generation Commands
+
+```bash
+# Development documentation (rules/)
+/create-rules_toc          # Incremental update (changed files only)
+/create-rules_toc --full   # Full rebuild
+
+# Requirements/design documents (specs/)
+/create-specs_toc          # Incremental update
+/create-specs_toc --full   # Full rebuild
+```
+
+### Advisor Agents
+
+Automatically identify documents needed for a task:
+
+```
+Task(subagent_type: rules-advisor, prompt: "Identify documents for implementing user authentication")
+Task(subagent_type: specs-advisor, prompt: "Find requirements for screen navigation")
+```
+
+### Recommended CLAUDE.md Entry
+
+Add the following to your project's `CLAUDE.md` to make Claude automatically reference documents:
+
+```markdown
+## Task Execution Flow [MANDATORY]
+
+When receiving a work task, follow this flow:
+
+1. Identify rule documents with rules-advisor Subagent
+```
+   Task(subagent_type: rules-advisor, prompt: [task description])
+   ```
+
+2. Identify requirements/design documents with specs-advisor Subagent
+   ```
+   Task(subagent_type: specs-advisor, prompt: [task description])
+   ```
+
+3. Read **all** required documents (or pass to Subagent)
+
+4. Execute the task
+   ```
+
+## Architecture
+
+### Configuration File
+
+The scripts use the following configuration file:
+
+- `.claude/doc-advisor/config.yaml`
+
+### ToC Generation Flow
+
+```
+/create-*_toc
+        |
+        v
++-------------------------------------+
+| 1. Detect changes (SHA-256 hash)    |
+|    Compare checksums -> changed only |
++------------------+------------------+
+                   |
+                   v
++-------------------------------------+
+| 2. Parallel processing (max 5)      |
+|    *-toc-updater agents             |
+|    Each agent: read .md -> write YAML|
++------------------+------------------+
+                   |
+                   v
++-------------------------------------+
+| 3. Merge & Validate -> *_toc.yaml   |
++-------------------------------------+
+```
+
+### Advisor Flow
+
+```
+Task(subagent_type: *-advisor)
+        |
+        v
++-------------------+     +-------------------+
+| Read *_toc.yaml   |---->| Find relevant     |----> Return file paths
+|                   |     | documents         |
++-------------------+     +-------------------+
+```
+
+## Directory Structure
+
+### Template Repository
+
+```
+DocAdvisor-CC/
+├── templates/
+│   ├── commands/               # Command templates
+│   │   ├── create-rules_toc.md
+│   │   └── create-specs_toc.md
+│   ├── agents/                 # Agent templates
+│   │   ├── rules-advisor.md
+│   │   ├── specs-advisor.md
+│   │   ├── rules-toc-updater.md
+│   │   └── specs-toc-updater.md
+│   ├── skills/                 # Skill templates
+│   │   └── doc-advisor/        # ToC generation scripts
+│   └── doc-advisor/
+│       └── docs/               # ToC format/workflow documentation
+├── setup.sh                    # Project setup script
+├── Makefile                    # Build automation
+└── README.md
+```
+
+### Target Project Structure (after setup)
+
+```
+your-project/
+├── .claude/
+│   ├── commands/
+│   │   ├── create-rules_toc.md
+│   │   └── create-specs_toc.md
+│   ├── agents/
+│   │   ├── rules-advisor.md
+│   │   ├── specs-advisor.md
+│   │   ├── rules-toc-updater.md
+│   │   └── specs-toc-updater.md
+│   ├── skills/
+│   │   └── doc-advisor/        # ToC generation scripts
+│   └── doc-advisor/
+│       ├── config.yaml
+│       ├── docs/               # ToC format/workflow documentation
+│       ├── rules/              # Generated artifacts for rules
+│       │   ├── rules_toc.yaml
+│       │   ├── .toc_checksums.yaml
+│       │   └── .toc_work/
+│       └── specs/              # Generated artifacts for specs
+│           ├── specs_toc.yaml
+│           ├── .toc_checksums.yaml
+│           └── .toc_work/
+├── rules/                      # Rules documentation (configurable)
+│   └── *.md                    # Documentation files
+└── specs/                      # Specs documentation (configurable)
+    ├── requirements/           # Requirement documents
+    └── design/                 # Design documents
+```
+
+## Configuration
+
+### Project Configuration
+
+Located at `.claude/doc-advisor/config.yaml`:
+
+```yaml
+# === rules configuration ===
+rules:
+  root_dir: rules
+  toc_file: .claude/doc-advisor/rules/rules_toc.yaml
+  checksums_file: .claude/doc-advisor/rules/.toc_checksums.yaml
+  work_dir: .claude/doc-advisor/rules/.toc_work/
+
+  patterns:
+    target_glob: "**/*.md"
+    exclude:
+      # - reference    # Uncomment to exclude
+      # - archive
+
+  output:
+    header_comment: "Development documentation search index for rules-advisor subagent"
+    metadata_name: "Development Documentation Search Index"
+
+# === specs configuration ===
+specs:
+  root_dir: specs
+  toc_file: .claude/doc-advisor/specs/specs_toc.yaml
+  checksums_file: .claude/doc-advisor/specs/.toc_checksums.yaml
+  work_dir: .claude/doc-advisor/specs/.toc_work/
+
+  patterns:
+    target_dirs:
+      requirement: requirements
+      design: design
+    exclude:
+      - plan           # Read in full during work, no search needed
+      # - reference
+      # - /info/
+
+  output:
+    header_comment: "Requirements and design document search index for specs-advisor subagent"
+    metadata_name: "Requirements and Design Document Search Index"
+
+# === common configuration ===
+common:
+  parallel:
+    max_workers: 5
+    fallback_to_serial: true
+```
+
+> **Note**: System files (`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`) are automatically excluded and do not need to be listed in config.
+
+### Customizing Configuration
+
+Edit the project config file directly, or re-run setup:
+
+```bash
+# Re-run setup interactively
+./setup.sh /path/to/your-project
+
+# Or edit directly
+nano /path/to/your-project/.claude/doc-advisor/config.yaml
+```
+
+## Processing Modes
+
+| Mode | Description |
+|------|-------------|
+| full | Scan all files and regenerate ToC |
+| incremental | Process only changed files (SHA-256 hash detection) |
+| continuation | Resume interrupted processing |
+
+## Requirements
+
+- Python 3 (standard library only)
+- Claude Code
+- Bash shell
+
+## Troubleshooting
+
+### Config not found error
+
+Ensure you've run setup for your project:
+```bash
+./setup.sh /path/to/your-project
+```
+
+### Commands not recognized
+
+Verify the files exist:
+```bash
+ls -la /path/to/your-project/.claude/commands/
+ls -la /path/to/your-project/.claude/agents/
+```
+
+### ToC generation fails
+
+1. Check if target directories exist in your project
+2. Verify config paths are correct
+3. Look for `.claude/doc-advisor/{rules,specs}/.toc_work/` for recovery
+
+## Migration from v2.0 (Plugin Mode)
+
+If you were using the plugin mode (`--plugin-dir`), follow these steps:
+
+1. Run setup.sh on your project to install the new files
+2. Remove the `--plugin-dir` flag when starting Claude Code
+3. Your existing `config.yaml` in `.claude/doc-advisor/` will be preserved
+
+## License
+
+MIT License

--- a/TECHNICAL_GUIDE.md
+++ b/TECHNICAL_GUIDE.md
@@ -123,6 +123,8 @@ Setup will interactively ask for:
 - Specs directory (default: `specs/`)
 - Requirements subdirectory name (default: `requirements`)
 - Design subdirectory name (default: `design`)
+- Plan subdirectory name (default: `plan`)
+- Agent model (default: `opus`, options: `opus/sonnet/haiku/inherit`)
 
 ### 3. Launch Claude Code
 
@@ -341,6 +343,7 @@ common:
 ```
 
 > **Note**: System files (`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`) are automatically excluded and do not need to be listed in config.
+> **Note**: Exclude patterns are matched against directory paths only (filenames are not matched).
 
 ### Customizing Configuration
 

--- a/TECHNICAL_GUIDE_ja.md
+++ b/TECHNICAL_GUIDE_ja.md
@@ -1,0 +1,405 @@
+# Doc Advisor (v3.0)
+
+[![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Doc Advisorは、生成AIのコンテキストをクリーンに保つため、ドキュメントをインデックス化し、生成AIに必要なドキュメントのみを精選して渡します。
+
+## なぜ ToC（目次）が必要か
+
+生成AIには構造的な限界があります：
+
+- **Lost in the Middle**: 長いコンテキストの「真ん中」の情報は見落とされる
+- **Attention Dilution**: 入力が長いほど各トークンへの注意が希薄化
+
+**解決策**: 「全部読ませる」のではなく「必要なものだけ渡す」
+
+Doc Advisor は、ドキュメントを事前にインデックス化し、タスクに必要なファイルだけをAIに渡します。
+
+## 概要
+
+Doc Advisor は、プロジェクトのドキュメントを自動的にインデックス化し、AI エージェントが必要な文書を素早く特定できるようにするツールです。
+
+### 主な機能
+
+- **自動 ToC 生成**: ドキュメントの内容を分析し、検索可能な構造化インデックスを自動生成
+- **差分更新**: SHA-256 ハッシュで変更を検出し、変更されたファイルのみを処理
+- **並列処理**: 最大5並列でドキュメント処理を高速化
+- **中断耐性**: 処理中断時も完了分は保持、再開可能
+- **プロジェクトベースのセットアップ**: すべてのファイルがプロジェクトにコピーされ、プラグインモード不要
+
+## ドキュメントモデル
+
+Doc Advisor は **rule** と **spec** の2つのカテゴリのドキュメントを管理します。
+
+| カテゴリ | ディレクトリ | 用途 | 設定可能 |
+|----------|--------------|------|----------|
+| rule | `rules/` | 開発ドキュメント | Yes |
+| spec | `specs/` | プロジェクト仕様 | Yes |
+
+### rule - 開発ドキュメント
+
+自由形式の構造。任意のサブディレクトリ内の `.md` ファイルがインデックス化されます。
+
+| コンテンツ種別 | 例 |
+|----------------|-----|
+| アーキテクチャルール | `rules/core/architecture.md` |
+| コーディング規約 | `rules/coding/naming_convention.md` |
+| ワークフローガイド | `rules/workflow/review_process.md` |
+
+### spec - プロジェクト仕様
+
+パス内にサブディレクトリ名が含まれていれば、自動的に doc_type が判定されます。
+
+| doc_type | サブディレクトリ | 目的 | 設定可能 |
+|----------|------------------|------|----------|
+| `requirement` | `requirements/` | 機能要件、ユースケース | Yes |
+| `design` | `design/` | 技術設計、アーキテクチャ決定 | Yes |
+| `plan` | `plan/` | プロジェクト計画（定義のみ、ToC対象外） | - |
+
+例:
+- `specs/requirements/login.md` → requirement
+- `specs/main/design/architecture.md` → design
+- `specs/auth/oauth/requirements/api.md` → requirement
+
+### ToC 生成の仕組み
+
+#### 探索範囲
+
+`specs/` 配下を再帰的に探索し、パスに `requirement` または `design` ディレクトリが含まれるファイルを対象とします。深さ制限はありません。
+
+| パス例 | 対象 | 理由 |
+|--------|------|------|
+| `specs/feature1/requirements/app.md` | ✅ | `requirements` を含む |
+| `specs/main/sub/design/api.md` | ✅ | `design` を含む |
+| `specs/feature1/plan/task.md` | ❌ | 対象外 |
+
+#### plan が対象外の理由
+
+`plan` ディレクトリは ToC の対象外です。理由：
+
+1. **作業中に全文読む**: plan は実行時に全文参照するため、検索インデックスによる部分参照は不要
+2. **定義済みの実行計画**: requirement/design は「何を作るか」の参照用、plan は「どう作るか」の定義済み実行計画
+
+#### 処理時間
+
+| 処理 | 実行者 | 速度 |
+|------|--------|------|
+| 再帰探索 | Python (`rglob`) | 高速 |
+| 差分検出 | Python (SHA-256) | 高速 |
+| 内容解析 | Claude (LLM) | **遅い** |
+| 統合 | Python | 高速 |
+
+ボトルネックは LLM による解析です。インクリメンタルモード（デフォルト）では変更ファイルのみ処理することで最適化しています。
+
+## インストール
+
+### 1. リポジトリをクローン
+
+```bash
+git clone https://github.com/BlueEventHorizon/DocAdvisor-CC.git
+```
+
+### 2. ターゲットプロジェクトをセットアップ
+
+`setup.sh` をターゲットプロジェクトのパスで実行：
+
+```bash
+cd DocAdvisor-CC
+./setup.sh /path/to/your-project
+```
+
+これにより、必要なファイルがプロジェクトにコピーされます：
+```
+your-project/.claude/
+├── commands/          # コマンドファイル
+├── agents/            # エージェント定義
+├── skills/            # スキルモジュール
+└── doc-advisor/
+    ├── config.yaml    # プロジェクト設定
+    └── docs/          # ToC フォーマット/ワークフロー文書
+```
+
+セットアップは対話形式で以下を聞いてきます：
+- Rules ディレクトリ（デフォルト: `rules/`）
+- Specs ディレクトリ（デフォルト: `specs/`）
+- Requirements サブディレクトリ名（デフォルト: `requirements`）
+- Design サブディレクトリ名（デフォルト: `design`）
+
+### 3. Claude Code を起動
+
+```bash
+cd /path/to/your-project
+claude
+```
+
+`--plugin-dir` フラグは不要です！すべてのファイルは既にプロジェクト内にあります。
+
+### Makefile を使用（代替方法）
+
+```bash
+cd DocAdvisor-CC
+make setup                            # 対話モード
+make setup TARGET=/path/to/your-project  # ターゲット指定
+```
+
+## 使い方
+
+### ToC 生成コマンド
+
+```bash
+# 開発ドキュメント（rules/）の ToC 生成
+/create-rules_toc          # 差分更新（変更ファイルのみ処理）
+/create-rules_toc --full   # 全ファイル再生成
+
+# 要件定義書・設計書（specs/）の ToC 生成
+/create-specs_toc          # 差分更新
+/create-specs_toc --full   # 全ファイル再生成
+```
+
+### Advisor エージェント
+
+タスクに必要なドキュメントを自動特定：
+
+```
+Task(subagent_type: rules-advisor, prompt: "ユーザー認証機能の実装に必要な文書を特定")
+Task(subagent_type: specs-advisor, prompt: "画面遷移に関する要件定義書を特定")
+```
+
+### CLAUDE.md への推奨記載
+
+プロジェクトの `CLAUDE.md` に以下を追記すると、Claude が自動的にドキュメントを参照するようになります：
+
+```markdown
+## 作業タスク実施の基本フロー [MANDATORY]
+
+作業タスクを受け取ったら、以下のフローに従うこと：
+
+1. rules-advisor Subagent でルール文書を特定
+```
+   Task(subagent_type: rules-advisor, prompt: [タスク内容])
+   ```
+
+2. specs-advisor Subagent で要件定義書・設計書を特定
+   ```
+   Task(subagent_type: specs-advisor, prompt: [タスク内容])
+   ```
+
+3. 必要となる文書セット**全て**を読む（または Subagent に渡す）
+
+4. 作業タスクを実行
+   ```
+
+## アーキテクチャ
+
+### 設定ファイル
+
+スクリプトは以下の設定ファイルを使用します：
+
+- `.claude/doc-advisor/config.yaml`
+
+### ToC 生成フロー
+
+```
+/create-*_toc
+        |
+        v
++-------------------------------------+
+| 1. 変更検出 (SHA-256 ハッシュ)      |
+|    チェックサム比較 → 変更分のみ    |
++------------------+------------------+
+                   |
+                   v
++-------------------------------------+
+| 2. 並列処理 (最大5並列)             |
+|    *-toc-updater agents             |
+|    各エージェント: .md読込 → YAML出力|
++------------------+------------------+
+                   |
+                   v
++-------------------------------------+
+| 3. マージ & 検証 → *_toc.yaml       |
++-------------------------------------+
+```
+
+### Advisor フロー
+
+```
+Task(subagent_type: *-advisor)
+        |
+        v
++-------------------+     +-------------------+
+| *_toc.yaml 読込   |---->| 関連ドキュメント  |----> ファイルパス返却
+|                   |     | 検索              |
++-------------------+     +-------------------+
+```
+
+## ディレクトリ構造
+
+### テンプレートリポジトリ
+
+```
+DocAdvisor-CC/
+├── templates/
+│   ├── commands/               # コマンドテンプレート
+│   │   ├── create-rules_toc.md
+│   │   └── create-specs_toc.md
+│   ├── agents/                 # エージェントテンプレート
+│   │   ├── rules-advisor.md
+│   │   ├── specs-advisor.md
+│   │   ├── rules-toc-updater.md
+│   │   └── specs-toc-updater.md
+│   ├── skills/                 # スキルテンプレート
+│   │   └── doc-advisor/        # ToC 生成スクリプト
+│   └── doc-advisor/
+│       └── docs/               # ToC フォーマット/ワークフロー文書
+├── setup.sh                    # プロジェクトセットアップスクリプト
+├── Makefile                    # ビルド自動化
+└── README.md
+```
+
+### ターゲットプロジェクト構造（セットアップ後）
+
+```
+your-project/
+├── .claude/
+│   ├── commands/
+│   │   ├── create-rules_toc.md
+│   │   └── create-specs_toc.md
+│   ├── agents/
+│   │   ├── rules-advisor.md
+│   │   ├── specs-advisor.md
+│   │   ├── rules-toc-updater.md
+│   │   └── specs-toc-updater.md
+│   ├── skills/
+│   │   └── doc-advisor/        # ToC 生成スクリプト
+│   └── doc-advisor/
+│       ├── config.yaml
+│       ├── docs/               # ToC フォーマット/ワークフロー文書
+│       ├── rules/              # rules の生成成果物
+│       │   ├── rules_toc.yaml
+│       │   ├── .toc_checksums.yaml
+│       │   └── .toc_work/
+│       └── specs/              # specs の生成成果物
+│           ├── specs_toc.yaml
+│           ├── .toc_checksums.yaml
+│           └── .toc_work/
+├── rules/                      # Rules ドキュメント（設定可能）
+│   └── *.md                    # ドキュメントファイル
+└── specs/                      # Specs ドキュメント（設定可能）
+    ├── requirements/           # 要件定義書
+    └── design/                 # 設計書
+```
+
+## 設定
+
+### プロジェクト設定
+
+`.claude/doc-advisor/config.yaml` にあります：
+
+```yaml
+# === rules 設定 ===
+rules:
+  root_dir: rules
+  toc_file: .claude/doc-advisor/rules/rules_toc.yaml
+  checksums_file: .claude/doc-advisor/rules/.toc_checksums.yaml
+  work_dir: .claude/doc-advisor/rules/.toc_work/
+
+  patterns:
+    target_glob: "**/*.md"
+    exclude:
+      # - reference    # 必要に応じてコメント解除
+      # - archive
+
+  output:
+    header_comment: "Development documentation search index for rules-advisor subagent"
+    metadata_name: "Development Documentation Search Index"
+
+# === specs 設定 ===
+specs:
+  root_dir: specs
+  toc_file: .claude/doc-advisor/specs/specs_toc.yaml
+  checksums_file: .claude/doc-advisor/specs/.toc_checksums.yaml
+  work_dir: .claude/doc-advisor/specs/.toc_work/
+
+  patterns:
+    target_dirs:
+      requirement: requirements
+      design: design
+    exclude:
+      - plan           # 作業中に全文読むため、検索不要
+      # - reference
+      # - /info/
+
+  output:
+    header_comment: "Requirements and design document search index for specs-advisor subagent"
+    metadata_name: "Requirements and Design Document Search Index"
+
+# === 共通設定 ===
+common:
+  parallel:
+    max_workers: 5
+    fallback_to_serial: true
+```
+
+> **注**: システムファイル（`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`）は自動的に除外されるため、設定に記載する必要はありません。
+
+### 設定のカスタマイズ
+
+プロジェクト設定ファイルを直接編集するか、セットアップを再実行：
+
+```bash
+# 対話形式で再セットアップ
+./setup.sh /path/to/your-project
+
+# または直接編集
+nano /path/to/your-project/.claude/doc-advisor/config.yaml
+```
+
+## 処理モード
+
+| モード | 説明 |
+|--------|------|
+| full | 全ファイルをスキャンして ToC を再生成 |
+| incremental | 変更ファイルのみ処理（SHA-256 ハッシュで検出） |
+| 継続 | 中断された処理を再開 |
+
+## 必要要件
+
+- Python 3（標準ライブラリのみ）
+- Claude Code
+- Bash シェル
+
+## トラブルシューティング
+
+### 設定が見つからないエラー
+
+プロジェクトのセットアップを実行したか確認：
+```bash
+./setup.sh /path/to/your-project
+```
+
+### コマンドが認識されない
+
+ファイルが存在するか確認：
+```bash
+ls -la /path/to/your-project/.claude/commands/
+ls -la /path/to/your-project/.claude/agents/
+```
+
+### ToC 生成が失敗する
+
+1. ターゲットディレクトリがプロジェクトに存在するか確認
+2. 設定のパスが正しいか確認
+3. `.claude/doc-advisor/{rules,specs}/.toc_work/` で復旧を確認
+
+## v2.0（プラグインモード）からの移行
+
+プラグインモード（`--plugin-dir`）を使用していた場合：
+
+1. プロジェクトで setup.sh を実行して新しいファイルをインストール
+2. Claude Code 起動時に `--plugin-dir` フラグを削除
+3. `.claude/doc-advisor/` 内の既存の `config.yaml` は保持されます
+
+## ライセンス
+
+MIT License

--- a/TECHNICAL_GUIDE_ja.md
+++ b/TECHNICAL_GUIDE_ja.md
@@ -124,6 +124,8 @@ your-project/.claude/
 - Specs ディレクトリ（デフォルト: `specs/`）
 - Requirements サブディレクトリ名（デフォルト: `requirements`）
 - Design サブディレクトリ名（デフォルト: `design`）
+- Plan サブディレクトリ名（デフォルト: `plan`）
+- Agent model（デフォルト: `opus`、`opus/sonnet/haiku/inherit`）
 
 ### 3. Claude Code を起動
 
@@ -342,6 +344,7 @@ common:
 ```
 
 > **注**: システムファイル（`.toc_work/`, `*_toc.yaml`, `.toc_checksums.yaml`）は自動的に除外されるため、設定に記載する必要はありません。
+> **注**: 除外パターンはディレクトリパスに対して判定されます（ファイル名は対象外）。
 
 ### 設定のカスタマイズ
 

--- a/setup.sh
+++ b/setup.sh
@@ -149,7 +149,7 @@ case "$AGENT_MODEL" in
     opus|sonnet|haiku|inherit)
         ;;
     *)
-        echo -e "${YELLOW}Warning: Unknown model '$AGENT_MODEL'. Using 'opus' as default.${NC}"
+        echo -e "${RED}Warning: Unknown model '$AGENT_MODEL'. Using 'opus' as default.${NC}"
         AGENT_MODEL="opus"
         ;;
 esac
@@ -224,7 +224,7 @@ copy_dir_with_substitution() {
     local dst_dir="$2"
 
     if [[ ! -d "$src_dir" ]]; then
-        echo "Warning: Source directory not found: $src_dir"
+        echo -e "${RED}Warning: Source directory not found: ${src_dir}${NC}"
         return
     fi
 


### PR DESCRIPTION
## 概要

- README.md / README_ja.md を簡素化し、プロジェクト概要に集中
- 技術詳細を TECHNICAL_GUIDE.md / TECHNICAL_GUIDE_ja.md に分離

## 背景

READMEが肥大化し、ユーザーが必要な情報を素早く見つけにくくなっていたため、ドキュメント構成を整理した。

## やったこと

- README.md / README_ja.md: 技術詳細を削除し、プロジェクト概要・クイックスタートに集中
- TECHNICAL_GUIDE.md / TECHNICAL_GUIDE_ja.md: 新規作成、アーキテクチャ・設定詳細・トラブルシューティング等の技術情報を移動
- setup.sh: 軽微な修正

## やらないこと（このプルリクエストのスコープ外とすること）

- 機能変更なし
- コード変更なし（ドキュメントのみ）

## 画面設計書

N/A

## デザイン仕様書

N/A

## API仕様書

N/A

## レビュー観点

- ドキュメントの構成が適切か
- 情報の分割が論理的か
- 英語版と日本語版で内容に齟齬がないか

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- Lv1: ぱっとみて違和感がないかチェックしてAcceptする
- ~~Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする~~
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## スクリーンショット

N/A

## 備考

ドキュメントのリファクタリングのみ。