### PR TITLE
[Fix] prepare_toc の --dirs-json 誤用ガード + Task→Agent 表記修正

### DIFF
--- a/docs/specs/base/design/DES-005_toc_generation_flow.md
+++ b/docs/specs/base/design/DES-005_toc_generation_flow.md
@@ -331,7 +331,7 @@ docs:
 ```json
 {
   "status": "ok | error | partial",
-  "error_code": "INVALID_PATH | PATH_TRAVERSAL | ABSOLUTE_PATH | OUTSIDE_ROOT | NOT_FOUND | NOT_MARKDOWN | KEY_EMPTY | KEY_RESERVED | TOC_NOT_FOUND | NO_TARGETS | null",
+  "error_code": "INVALID_PATH | PATH_TRAVERSAL | ABSOLUTE_PATH | OUTSIDE_ROOT | NOT_FOUND | NOT_MARKDOWN | KEY_EMPTY | KEY_RESERVED | TOC_NOT_FOUND | NO_TARGETS | UNSUPPORTED_ARG | null",
   "message": "human-readable",
   "key": "rules",
   "toc_path": ".claude/doc-advisor/toc/rules-<hash>/toc.yaml",

--- a/scripts/prepare_toc.py
+++ b/scripts/prepare_toc.py
@@ -327,6 +327,18 @@ def parse_args(argv=None):
         "--dry-run", action="store_true",
         help="Compute diff without generating pending YAML",
     )
+    # 誤用ガード: ディレクトリ展開は prepare_toc の責務ではなく expand_dirs.py / index-docs
+    # SKILL が担う。argparse の不親切な "unrecognized arguments" を、実行可能な誘導エラーに
+    # 変えるために認識だけして main で UNSUPPORTED_ARG として弾く。
+    parser.add_argument(
+        "--dirs-json",
+        help="NOT supported here. Expand dirs with expand_dirs.py first, "
+             "or use the index-docs skill which orchestrates expansion.",
+    )
+    parser.add_argument(
+        "--exclude-json",
+        help="NOT supported here (only meaningful with --dirs-json). See expand_dirs.py.",
+    )
     return parser.parse_args(argv)
 
 
@@ -367,6 +379,21 @@ def load_input_paths(args):
 def main(argv=None):
     args = parse_args(argv)
     project_root = get_project_root()
+
+    # 0. 誤用ガード: --dirs-json / --exclude-json は prepare_toc の責務外（DES-005 §5.1）。
+    #    expand_dirs.py で paths に展開してから --paths-json で渡すか、index-docs SKILL を使う。
+    if args.dirs_json is not None or args.exclude_json is not None:
+        emit_json(
+            STATUS_ERROR,
+            error_code=ErrorCode.UNSUPPORTED_ARG,
+            message=(
+                "prepare_toc.py does not expand directories. "
+                "Run expand_dirs.py first and pass its 'paths' output via --paths-json, "
+                "or use the index-docs skill which orchestrates expansion automatically "
+                "(--dirs-json/--exclude-json are handled there, not here)."
+            ),
+        )
+        return 1
 
     # 1. key 解決（--all / --key 省略 → 予約 all、--key all → KEY_RESERVED）
     try:

--- a/scripts/toc_store.py
+++ b/scripts/toc_store.py
@@ -85,6 +85,7 @@ class ErrorCode:
     KEY_RESERVED = "KEY_RESERVED"
     TOC_NOT_FOUND = "TOC_NOT_FOUND"
     NO_TARGETS = "NO_TARGETS"
+    UNSUPPORTED_ARG = "UNSUPPORTED_ARG"
 
 
 # error_code の有効値集合（None を含む）。テスト・バリデーションで参照する。
@@ -99,6 +100,7 @@ ERROR_CODES = frozenset({
     ErrorCode.KEY_RESERVED,
     ErrorCode.TOC_NOT_FOUND,
     ErrorCode.NO_TARGETS,
+    ErrorCode.UNSUPPORTED_ARG,
 })
 
 # status の有効値集合（DES-005 §8.2）。

--- a/skills/index-docs/SKILL.md
+++ b/skills/index-docs/SKILL.md
@@ -10,7 +10,7 @@ description: |
   Trigger:
   - After an upper layer decides a key and its desired-state paths
   - "Index docs", "Rebuild the ToC for key X", "Index all Markdown"
-allowed-tools: Bash, Read, Task
+allowed-tools: Bash, Read, Agent
 user-invocable: true
 argument-hint: "--key <key> --paths-json '[...]' | --key <key> --dirs-json '[...]' | --all | (no args = --all)"
 ---
@@ -33,14 +33,14 @@ key + project-root-relative paths から ToC（AI 検索用インデックス）
 /doc-advisor:index-docs --all
 ```
 
-| Argument                | Description                                                                                          |
-| ----------------------- | ---------------------------------------------------------------------------------------------------- |
-| `--key <key>`           | 対象 ToC の opaque key（上位層が決定）。`all` は予約語のため任意指定不可（reject される）            |
-| `--paths-json '[...]'`  | 当該 key の **完全な desired state** となる project-root-relative path の JSON 配列                  |
-| `--dirs-json '[...]'`   | 展開するディレクトリの JSON 配列（`--paths-json` と併用可）。SKILL が rglob で Markdown を収集する   |
-| `--exclude-json '[...]'`| `--dirs-json` 展開時に除外するパス・ディレクトリの JSON 配列（システム固定除外は常時適用）           |
-| `--paths-file <path>`   | paths 配列を含む JSON ファイル（`--paths-json` の代替）                                              |
-| `--all`                 | 単体モード。`--key` 省略と同義で予約 key `all` に解決し、project root 以下の全 Markdown を対象にする |
+| Argument                 | Description                                                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `--key <key>`            | 対象 ToC の opaque key（上位層が決定）。`all` は予約語のため任意指定不可（reject される）            |
+| `--paths-json '[...]'`   | 当該 key の **完全な desired state** となる project-root-relative path の JSON 配列                  |
+| `--dirs-json '[...]'`    | 展開するディレクトリの JSON 配列（`--paths-json` と併用可）。SKILL が rglob で Markdown を収集する   |
+| `--exclude-json '[...]'` | `--dirs-json` 展開時に除外するパス・ディレクトリの JSON 配列（システム固定除外は常時適用）           |
+| `--paths-file <path>`    | paths 配列を含む JSON ファイル（`--paths-json` の代替）                                              |
+| `--all`                  | 単体モード。`--key` 省略と同義で予約 key `all` に解決し、project root 以下の全 Markdown を対象にする |
 
 > **desired-state の破壊性 [MANDATORY]**: `--paths-json` / `--paths-file` で渡す paths は当該 key の **完全な desired state** である。前回 ToC に存在し今回 paths に含まれない path は **削除** される（部分配列を渡すと残りが消える）。上位層の責務であり、不安な場合は先に `prepare_toc.py --dry-run` で削除予定を確認すること（後述）。
 
@@ -119,17 +119,17 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/prepare_toc.py --all
 
 `store_dir/.toc_work/*.yaml`（隠しファイル `.` 始まりは除く）のうち `_meta.status: pending` のものを、`doc-advisor:toc-updater` カスタム Agent で **並列充填**する。
 
-- **並列数**: 最大 5（`toc_orchestrator.md` の既定）。CRITICAL: 1 つの assistant メッセージ内で複数の Task 呼び出しをまとめて発行する（1 件ずつ別メッセージにすると並列にならない）。
+- **並列数**: 最大 5（`toc_orchestrator.md` の既定）。CRITICAL: 1 つの assistant メッセージ内で複数の Agent 呼び出しをまとめて発行する（1 件ずつ別メッセージにすると並列にならない）。
 - **`run_in_background: true` は使わない**（Phase 2 ループが壊れる）。
 - 各カスタム Agent には key と entry_file を渡す。`subagent_type` には `doc-advisor:toc-updater` を指定する。
 
 ```
 # key 指定時（1 メッセージで最大 5 件並列）
-Task(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/<sha256>.yaml")
+Agent(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/<sha256>.yaml")
 ...（最大 5 件）
 
 # 単体モード（予約 key all）: key の代わりに all を渡す
-Task(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_file: .claude/doc-advisor/toc/all-<hash>/.toc_work/<sha256>.yaml")
+Agent(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_file: .claude/doc-advisor/toc/all-<hash>/.toc_work/<sha256>.yaml")
 ```
 
 > 単体モードでは toc-updater 側が `write_pending.py --all` を使う（`--key all` はユーザー任意指定として reject されるため）。`entry_file` は project-root-relative で渡す。

--- a/tests/scripts/test_prepare_toc.py
+++ b/tests/scripts/test_prepare_toc.py
@@ -526,6 +526,24 @@ class TestKeyAndJsonContract(PrepareTestBase):
         obj = self._parse_stdout(proc)
         self.assertEqual(obj["error_code"], "INVALID_PATH")
 
+    def test_dirs_json_rejected_with_guidance(self):
+        """--dirs-json は誤用ガードで UNSUPPORTED_ARG を返し、誘導文を含む。"""
+        proc = self._run('--key', 'rules', '--dirs-json', '["docs/rules/"]')
+        self.assertNotEqual(proc.returncode, 0)
+        obj = self._parse_stdout(proc)
+        self.assertEqual(obj["status"], "error")
+        self.assertEqual(obj["error_code"], "UNSUPPORTED_ARG")
+        # 実行可能な誘導: expand_dirs.py と index-docs を案内する
+        self.assertIn("expand_dirs.py", obj["message"])
+        self.assertIn("index-docs", obj["message"])
+
+    def test_exclude_json_rejected_with_guidance(self):
+        """--exclude-json 単独でも誤用ガードで UNSUPPORTED_ARG を返す。"""
+        proc = self._run('--key', 'rules', '--exclude-json', '["docs/draft/"]')
+        self.assertNotEqual(proc.returncode, 0)
+        obj = self._parse_stdout(proc)
+        self.assertEqual(obj["error_code"], "UNSUPPORTED_ARG")
+
     def test_paths_file_input(self):
         """--paths-file から JSON を読み込める。"""
         self._write_md("docs/a.md")

--- a/tests/scripts/test_toc_store.py
+++ b/tests/scripts/test_toc_store.py
@@ -249,7 +249,7 @@ class TestEmitJson(unittest.TestCase):
         expected = {
             "INVALID_PATH", "PATH_TRAVERSAL", "ABSOLUTE_PATH", "OUTSIDE_ROOT",
             "NOT_FOUND", "NOT_MARKDOWN", "KEY_EMPTY", "KEY_RESERVED",
-            "TOC_NOT_FOUND", "NO_TARGETS",
+            "TOC_NOT_FOUND", "NO_TARGETS", "UNSUPPORTED_ARG",
         }
         self.assertEqual(set(ERROR_CODES), expected)
 

--- a/workflows/toc_orchestrator.md
+++ b/workflows/toc_orchestrator.md
@@ -143,7 +143,7 @@ Use `ls .toc_work/*.yaml` or `while read` loops instead.
 2. If no pending files → Go to Phase 3 (merge)
     ↓
 3. Use max_workers = 5 (default).
-   CRITICAL: Launch up to N Task tool calls in a SINGLE assistant message.
+   CRITICAL: Launch up to N Agent tool calls in a SINGLE assistant message.
    Do NOT launch them one at a time in separate messages — this defeats parallelism.
    Pass key (or `all` for single mode) and the entry_file (project-root-relative).
     ↓
@@ -182,12 +182,12 @@ Read the stdout JSON: `status` / `counts` / `deleted_paths` / `warnings`.
 ```
 # Launch 5 in parallel (filenames are SHA256 hashes of the source paths)
 # key specified
-Task(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/a1b2c3d4e5f67890.yaml")
-Task(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/1234567890abcdef.yaml")
+Agent(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/a1b2c3d4e5f67890.yaml")
+Agent(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/1234567890abcdef.yaml")
 ... (up to 5)
 
 # single mode (reserved key all): pass `all` instead of a key
-Task(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_file: .claude/doc-advisor/toc/all-<hash>/.toc_work/<sha256>.yaml")
+Agent(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_file: .claude/doc-advisor/toc/all-<hash>/.toc_work/<sha256>.yaml")
 ```
 
 > In single mode the agent uses `write_pending.py --all` (`--key all` is rejected as a user-specified key).

--- a/workflows/toc_update_workflow.md
+++ b/workflows/toc_update_workflow.md
@@ -137,13 +137,13 @@ Read `store_dir/.toc_work/*.yaml` (exclude hidden `.`-prefixed files) and identi
 **Parallel count**: default 5.
 
 ```
-# Orchestrator calls multiple Task tools in one message
+# Orchestrator calls multiple Agent tools in one message
 # key specified
-Task(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/<sha256>.yaml")
+Agent(subagent_type: doc-advisor:toc-updater, prompt: "key: {key}, entry_file: .claude/doc-advisor/toc/<slug>/.toc_work/<sha256>.yaml")
 ... (up to 5 simultaneously)
 
 # single mode (reserved key all): pass `all` instead of a key
-Task(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_file: .claude/doc-advisor/toc/all-<hash>/.toc_work/<sha256>.yaml")
+Agent(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_file: .claude/doc-advisor/toc/all-<hash>/.toc_work/<sha256>.yaml")
 ```
 
 **Note**: Do not use `xargs` for file listing — it fails with long Japanese filenames.


### PR DESCRIPTION
## 概要

- 生スクリプト `prepare_toc.py` を SKILL 抜きで手叩きした際の誤用（`--dirs-json` 直渡し）を、実行可能なエラーで防ぐガードを追加
- v2.1.63 のツールリネームに伴う stale な `Task` 表記を `Agent` に統一

## 背景

実験中に index-docs SKILL を経由せず生スクリプトを手叩きし、`prepare_toc.py --dirs-json ...` を実行 → argparse が `unrecognized arguments: --dirs-json` という原因も次の手も不明なエラーを返した。`--dirs-json` の展開は `expand_dirs.py` / index-docs SKILL の責務であり、prepare_toc は paths のみ受ける設計。

また frontmatter・workflow の `Task(...)` 表記は、自リポジトリの `docs/rules/skill_launch_paths_definitions.md` が既に \"Agent ツール\" に統一済みであるのに未追従だった（v2.1.63 で `Task`→`Agent` にリネーム。`Task` はエイリアスとして動作するため機能上の不具合はなし）。

## やったこと

- `scripts/prepare_toc.py`: `--dirs-json` / `--exclude-json` を認識し、main 冒頭で `UNSUPPORTED_ARG` エラー（expand_dirs.py を先に実行 or index-docs SKILL を使う旨の誘導文付き）を返す
- `scripts/toc_store.py`: `ErrorCode.UNSUPPORTED_ARG` を enum + `ERROR_CODES` に追加
- `tests/`: 誤用ガードのテスト2本 + enum 固定テスト（FR-N08-2）の更新
- `docs/specs/base/design/DES-005`: error_code 列挙に `UNSUPPORTED_ARG` を追記
- `skills/index-docs/SKILL.md` / `workflows/{toc_orchestrator,toc_update_workflow}.md`: ツール名としての `Task` を `Agent` に統一（「タスク」「task_」等の非ツール語は不変）

## やらないこと（このプルリクエストのスコープ外とすること）

- `expand`+`prepare` を1コマンドにまとめるラッパー（案 B）: fill フェーズが Agent 起動を要し純粋スクリプトに包めないため不採用
- guidance / issue #18 の実験本体（別ブランチ）
- 既存 drift の dprint 整形（toc-updater.md / DES-004 / REQ-001 / REQ-002。本 PR の変更外）

## レビュー観点

- 誤用ガードが正常系（`--paths-json` / `--paths-file` / `--all`）に干渉しないこと
- `Task`→`Agent` 置換がツール名のみで、文意の「タスク」を壊していないこと
- テスト386件 green / 変更8ファイルは dprint clean

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- ~~Lv1: ぱっとみて違和感がないかチェックしてAcceptする~~
- Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~