### PR TITLE
[Feature] index-docs の work-dir 状態判定を script 化（AI の手列挙・手導出を排除）

### DIFF
--- a/scripts/toc_store.py
+++ b/scripts/toc_store.py
@@ -32,6 +32,7 @@ from toc_utils import (
     get_project_root,
     normalize_path,
     yaml_escape,
+    load_entry_file,
     log,
 )
 
@@ -275,6 +276,7 @@ def emit_json(
     deleted_paths=None,
     warnings=None,
     external_pending=None,
+    extra=None,
     stream=None,
 ):
     """stdout に単一 JSON を出力する（DES-005 §8.1 / FR-N08-1）。
@@ -296,6 +298,7 @@ def emit_json(
         warnings: warning 文字列リスト
         external_pending: 未承認の越境 symlink リスト
             [{symlink, resolved, affected_count}]（needs_confirmation 時。NFR-N06）
+        extra: 追加フィールドの dict（payload にマージ）。work-status 出力等に使う
         stream: 出力先（省略時 sys.stdout。テスト用）
     """
     payload = {
@@ -320,6 +323,8 @@ def emit_json(
         payload["warnings"] = warnings
     if external_pending is not None:
         payload["external_pending"] = external_pending
+    if extra is not None:
+        payload.update(extra)
 
     out = stream if stream is not None else sys.stdout
     out.write(json.dumps(payload, ensure_ascii=False))
@@ -398,6 +403,73 @@ def clean_work_dir(store_dir):
     return True
 
 
+def _entry_file_rel(filepath, project_root):
+    """entry_file を project-root 相対の POSIX 文字列で返す（外なら絶対）。"""
+    try:
+        return normalize_path(Path(filepath).relative_to(Path(project_root)))
+    except ValueError:
+        return normalize_path(Path(filepath))
+
+
+def work_status(store_dir, project_root):
+    """key の `.toc_work/` 状態と継続判定を返す（決定論・純粋関数 / index-docs Step 0・2）。
+
+    index-docs SKILL が AI に手作業させていた「`.toc_work` 有無判定 / pending 列挙 /
+    completed・error 分類 / 継続判定」を script 化する（Issue #22 A1）。
+
+    Args:
+        store_dir: store_dir の Path
+        project_root: project root（entry_file を相対化するため）
+
+    Returns:
+        dict:
+            has_work_dir (bool): `.toc_work/` が存在するか
+            pending (list[str]): 未充填 entry_file（project-root 相対）。toc-updater 起動対象
+            completed (int): status == 'completed' の件数
+            error_pending (list[dict]): [{entry_file, error_message}]（充填試行済みエラー）
+            next_action (str): 'prepare'（work-dir なし）/ 'fill'（pending あり）/ 'merge'（pending なし）
+    """
+    store_dir = Path(store_dir)
+    work_dir = store_dir / WORK_DIRNAME
+    result = {
+        "has_work_dir": work_dir.exists(),
+        "pending": [],
+        "completed": 0,
+        "error_pending": [],
+        "next_action": "prepare",
+    }
+    if not work_dir.exists():
+        return result
+
+    # 隠しファイル（.toc_checksums_pending.yaml / .deleted.json 等）は entry でないため除外。
+    # 決定的順序（merge と同一の sorted）で列挙する。
+    yaml_files = sorted(
+        f for f in work_dir.glob("*.yaml") if not f.name.startswith(".")
+    )
+    for filepath in yaml_files:
+        rel = _entry_file_rel(filepath, project_root)
+        try:
+            meta, _entry = load_entry_file(filepath)
+        except IOError:
+            # 読めない pending は要再処理として pending に含める（取りこぼし防止）
+            result["pending"].append(rel)
+            continue
+        error_message = meta.get("error_message")
+        status = meta.get("status")
+        if error_message:
+            result["error_pending"].append(
+                {"entry_file": rel, "error_message": error_message}
+            )
+        elif status == "completed":
+            result["completed"] += 1
+        else:
+            result["pending"].append(rel)
+
+    # 継続判定: 充填可能な pending が残れば fill、無ければ（completed/error/空のみ）merge。
+    result["next_action"] = "fill" if result["pending"] else "merge"
+    return result
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -420,6 +492,10 @@ def parse_args(argv=None):
     parser.add_argument(
         "--clean-work-dir", action="store_true",
         help="Remove the work directory",
+    )
+    parser.add_argument(
+        "--work-status", action="store_true",
+        help="Emit .toc_work status (pending entry_files / completed / next_action) as JSON",
     )
     return parser.parse_args(argv)
 
@@ -444,11 +520,11 @@ def resolve_key_from_args(args):
 def main(argv=None):
     args = parse_args(argv)
 
-    if not args.promote_pending and not args.clean_work_dir:
+    if not args.promote_pending and not args.clean_work_dir and not args.work_status:
         emit_json(
             STATUS_ERROR,
             error_code=ErrorCode.NO_TARGETS,
-            message="No action specified (use --promote-pending or --clean-work-dir)",
+            message="No action specified (use --work-status / --promote-pending / --clean-work-dir)",
         )
         return 1
 
@@ -460,6 +536,18 @@ def main(argv=None):
 
     project_root = get_project_root()
     store_dir = resolve_store_dir(key, project_root)
+
+    # --work-status は読み取り専用。promote/clean とは独立に処理して即返す。
+    if args.work_status:
+        status = work_status(store_dir, project_root)
+        emit_json(
+            STATUS_OK,
+            error_code=None,
+            key=key,
+            toc_path=toc_path_rel(store_dir, project_root),
+            extra=status,
+        )
+        return 0
 
     ok = True
     if args.promote_pending:

--- a/skills/index-docs/SKILL.md
+++ b/skills/index-docs/SKILL.md
@@ -60,15 +60,21 @@ key + project-root-relative paths から ToC（AI 検索用インデックス）
 
 ### Step 0: 中断耐性・continuation の判定（key 単位 / §6.6）
 
-各 key の `.toc_work/` は当該 key の `store_dir/.toc_work/` に分離される（key ごとに別ディレクトリのため、複数 key を扱っても競合しない）。処理開始時に当該 key の `.toc_work/` 残存を判定する。
+各 key の `.toc_work/` は当該 key の `store_dir/.toc_work/` に分離される（key ごとに別ディレクトリのため、複数 key を扱っても競合しない）。**判定は手作業（`test -d` / YAML の手読み）で行わず、`toc_store.py --work-status` の出力に従う**（決定論処理は script に委ねる）:
 
-| 状況                                                             | 判定                                                                                   |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `store_dir/.toc_work/` が存在し pending（`status: pending`）あり | `prepare_toc.py` を **再実行せず**、残 pending の充填（Step 2）から再開し merge へ進む |
-| `store_dir/.toc_work/` が存在し全 `completed`                    | 充填済み。merge（Step 3）へ直行する                                                    |
-| `store_dir/.toc_work/` なし                                      | 通常どおり Step 1（prepare）から開始する                                               |
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/toc_store.py --key "{key}" --work-status   # 単体モードは --all
+```
 
-`store_dir` は `prepare_toc.py` / `merge_toc.py` の JSON 出力 `toc_path`（`.claude/doc-advisor/toc/<slug>/toc.yaml`）の親ディレクトリとして特定できる。`.toc_work/` の存在は Bash の `test -d` で確認する。
+stdout の JSON から `next_action` / `pending` / `completed` / `error_pending` / `has_work_dir` を読み、`next_action` に従う:
+
+| `next_action` | 意味                                          | 動作                                                                     |
+| ------------- | --------------------------------------------- | ------------------------------------------------------------------------ |
+| `prepare`     | `.toc_work/` なし                             | 通常どおり Step 1（prepare）から開始する                                 |
+| `fill`        | 充填可能な pending あり                       | `prepare_toc.py` を **再実行せず** Step 2（充填）から再開し merge へ進む |
+| `merge`       | pending なし（全 completed / error 記録済み） | Step 3（merge）へ直行する                                                |
+
+> `store_dir` の特定や `.toc_work/` の有無・pending 列挙を AI が手で導出・走査しない。`--work-status` が `pending`（project-root 相対の entry_file 一覧）まで返すため、Step 2 はそのリストをそのまま使う。
 
 ### Step 0.5: ディレクトリ展開（`--dirs-json` 指定時のみ）
 
@@ -134,7 +140,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/prepare_toc.py --key "{key}" --paths-json 
 
 ### Step 2: toc-updater カスタム Agent による並列充填
 
-`store_dir/.toc_work/*.yaml`（隠しファイル `.` 始まりは除く）のうち `_meta.status: pending` のものを、`doc-advisor:toc-updater` カスタム Agent で **並列充填**する。
+充填対象は **`toc_store.py --work-status` の `pending`（project-root 相対の entry_file 一覧）**を使う。AI が `ls .toc_work/*.yaml` や YAML の `_meta.status` 手読みで列挙しない（決定論は script が担う）。`pending` の各 entry_file を `doc-advisor:toc-updater` カスタム Agent で **並列充填**する。
 
 - **並列数**: 最大 5（`toc_orchestrator.md` の既定）。CRITICAL: 1 つの assistant メッセージ内で複数の Agent 呼び出しをまとめて発行する（1 件ずつ別メッセージにすると並列にならない）。
 - **`run_in_background: true` は使わない**（Phase 2 ループが壊れる）。
@@ -151,7 +157,7 @@ Agent(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_
 
 > 単体モードでは toc-updater 側が `write_pending.py --all` を使う（`--key all` はユーザー任意指定として reject されるため）。`entry_file` は project-root-relative で渡す。
 
-各バッチ完了後、簡潔な進捗（例: "Batch 2/4 complete, 10 remaining"）のみ出力し、pending が残る限り並列起動を繰り返す。すべて `completed`（またはエラー記録済み pending）になったら Step 3 へ。ファイル一覧に `xargs` を使わない（長い日本語ファイル名で失敗する）。`ls .toc_work/*.yaml` か `while read` ループを使う。
+各バッチ完了後、**`toc_store.py --work-status` を再実行して残 `pending` を取得**し（AI が手で再走査しない）、簡潔な進捗（例: "Batch 2/4 complete, 10 remaining"）のみ出力する。`pending` が空（`next_action: merge`）になったら Step 3 へ。エラー記録済み pending は `error_pending` に分類され充填対象から外れる。
 
 ### Step 3: merge（統合 + 削除反映 / §6.5）
 

--- a/tests/scripts/test_toc_store.py
+++ b/tests/scripts/test_toc_store.py
@@ -48,6 +48,7 @@ from toc_store import (
     emit_json,
     promote_pending,
     clean_work_dir,
+    work_status,
 )
 
 TOC_STORE_SCRIPT = os.path.join(SCRIPTS_DIR, 'toc_store.py')
@@ -300,6 +301,79 @@ class TestPromoteAndClean(unittest.TestCase):
         """work dir 不在でも冪等に成功する。"""
         self.assertFalse(self.work_dir.exists())
         self.assertTrue(clean_work_dir(self.store_dir))
+
+
+# ===========================================================================
+# work_status（index-docs Step 0/2 の決定論判定 / Issue #22 A1）
+# ===========================================================================
+
+class TestWorkStatus(unittest.TestCase):
+    """work_status の継続判定・pending 列挙・completed/error 分類テスト。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.root = Path(self.tmpdir)
+        self.store_dir = self.root / "store"
+        self.work_dir = self.store_dir / toc_store.WORK_DIRNAME
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_entry(self, name, *, status="pending", source_file="rules/a.md",
+                     error_message=None):
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["_meta:", f"  source_file: {source_file}", f"  status: {status}"]
+        if error_message is not None:
+            lines.append(f"  error_message: {error_message}")
+        lines.append("title: T")
+        (self.work_dir / name).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def test_no_work_dir_means_prepare(self):
+        r = work_status(self.store_dir, self.root)
+        self.assertFalse(r["has_work_dir"])
+        self.assertEqual(r["next_action"], "prepare")
+        self.assertEqual(r["pending"], [])
+
+    def test_pending_means_fill_and_lists_entry_files(self):
+        self._write_entry("aaa.yaml", status="pending", source_file="rules/a.md")
+        self._write_entry("bbb.yaml", status="completed", source_file="rules/b.md")
+        r = work_status(self.store_dir, self.root)
+        self.assertTrue(r["has_work_dir"])
+        self.assertEqual(r["next_action"], "fill")
+        self.assertEqual(r["completed"], 1)
+        # entry_file は project-root 相対で列挙される
+        self.assertEqual(r["pending"], ["store/.toc_work/aaa.yaml"])
+
+    def test_all_completed_means_merge(self):
+        self._write_entry("aaa.yaml", status="completed")
+        self._write_entry("bbb.yaml", status="completed")
+        r = work_status(self.store_dir, self.root)
+        self.assertEqual(r["next_action"], "merge")
+        self.assertEqual(r["completed"], 2)
+        self.assertEqual(r["pending"], [])
+
+    def test_error_pending_classified_and_not_blocking_merge(self):
+        self._write_entry("aaa.yaml", status="completed")
+        self._write_entry("err.yaml", status="pending",
+                          error_message="extraction failed")
+        r = work_status(self.store_dir, self.root)
+        self.assertEqual(r["completed"], 1)
+        self.assertEqual(len(r["error_pending"]), 1)
+        self.assertEqual(r["error_pending"][0]["entry_file"], "store/.toc_work/err.yaml")
+        self.assertEqual(r["pending"], [])
+        # 充填可能 pending が無いので merge へ（error は試行済み）
+        self.assertEqual(r["next_action"], "merge")
+
+    def test_hidden_files_excluded(self):
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        (self.work_dir / toc_store.PENDING_CHECKSUMS_FILENAME).write_text(
+            "checksums: {}\n", encoding="utf-8")
+        (self.work_dir / ".deleted.json").write_text("[]", encoding="utf-8")
+        r = work_status(self.store_dir, self.root)
+        # 隠しファイルは entry でないため pending/completed に数えない → merge
+        self.assertEqual(r["pending"], [])
+        self.assertEqual(r["completed"], 0)
+        self.assertEqual(r["next_action"], "merge")
 
 
 # ===========================================================================


### PR DESCRIPTION
## 概要

index-docs の Step 0/2 で AI が手作業していた決定論処理（`.toc_work/` 走査・`_meta.status` 手読み・`store_dir` の文字列導出・pending 列挙・完了追跡）を script 化する。`toc_store.py --work-status` が状態と継続判定を JSON で返し、SKILL はそれに従う。AI に残る動作は toc-updater カスタム Agent の起動のみ。

## 変更内容

- `scripts/toc_store.py`: `--work-status`（`work_status()`）を追加。JSON で `has_work_dir` / `pending`（project-root 相対の entry_file 一覧）/ `completed` / `error_pending` / `next_action`（`prepare` | `fill` | `merge`）を返す。`emit_json` に汎用 `extra` を追加。
- `skills/index-docs/SKILL.md`: Step 0 / Step 2 を `--work-status` 駆動に書き換え、AI の手列挙・手導出・`test -d`・`ls .toc_work` の記述を除去。
- `tests/scripts/test_toc_store.py`: `TestWorkStatus` を 5 件追加。

## テスト

- [x] `python3 -m unittest discover -s tests -p 'test_*.py'` 全 406 件 PASS（回帰なし）
- [x] CLI スモーク `toc_store.py --key gs-rules --work-status` → `next_action: prepare`
- [x] `dprint check skills/index-docs/SKILL.md`

## 受け入れ基準（#22 のうち本 PR が満たす A 群）

- [x] A1 work-status スクリプト（pending entry_file 列挙・store_dir 導出・継続判定）
- [x] A2 pending 列挙の script 化（AI の手走査を排除）
- [x] A3 index-docs SKILL.md 改訂
- [x] A4 work_status 単体テスト

Part of #22 — 本体 index-docs 側。外部 golden テスト harness の script 化（B 群: gen_tasks / parse_results / score ガード / cleanup / runner / RUNBOOK）は #22 に残し別途対応する（外部 gitignore のため本 PR には含まない）。
