### PR TITLE
[Fix] index-docs review: block silent merge on fill errors + carry-forward checksums + sync workflows

### DIFF
--- a/scripts/merge_toc.py
+++ b/scripts/merge_toc.py
@@ -279,23 +279,44 @@ def detect_deleted(docs, prev_checksums, sidecar_deleted, project_root):
 # checksums 再計算（DES-005 §6.2 / FR-N02-6）
 # ---------------------------------------------------------------------------
 
-def compute_checksums_for_docs(docs, project_root):
+def compute_checksums_for_docs(docs, project_root, completed_paths=None, prev_checksums=None):
     """toc.yaml の最終 docs から checksums（path -> hash）を再計算する。
 
-    desired-state の最終結果（merge 後の docs キー集合）を checksums の正とする。
+    **重要（Issue #22 レビュー対応）**: 今回の run で実際に充填された（completed）doc のみ
+    現内容ハッシュを書く。それ以外（既存からの持ち越し entry）は **前回 checksum を引き継ぐ**。
+    こうしないと、改訂されたが充填に失敗した updated doc に対し「現内容ハッシュ」を書いてしまい、
+    次回 prepare が「変更なし」と誤判定して**改訂が二度と索引されない（stale 固定）**。
+    持ち越し doc に前回値を残せば、現内容と差が出る限り次回 prepare が「updated」と検知して再充填する。
+
+    - completed_paths に含まれる path → 現内容の sha256（充填済み＝entry は現内容由来）
+    - それ以外で prev_checksums に値あり → 前回値を引き継ぐ（unchanged は現内容と同値、
+      errored-updated は旧値が残り次回再検知される）
+    - どちらでもない（前回値なしの持ち越し。通常起きない）→ フォールバックで現内容ハッシュ
+
     実体が読めない path は除外する（検証で別途検出される）。
 
     Args:
         docs: 最終 docs（source_file -> entry）
         project_root: project root（Path）
+        completed_paths: 今回 run で充填された path の集合（None 互換: 全て現内容ハッシュ＝旧挙動）
+        prev_checksums: 前回 checksums（path -> hash）。持ち越し doc の引き継ぎ元
 
     Returns:
         dict: path -> sha256 hash
     """
     root = Path(project_root)
+    completed_paths = set(completed_paths) if completed_paths is not None else None
+    prev_checksums = prev_checksums or {}
     checksums = {}
     for path in docs.keys():
-        h = calculate_file_hash(root / path)
+        if completed_paths is None or path in completed_paths:
+            # 充填済み（または旧 API 互換）→ 現内容ハッシュ
+            h = calculate_file_hash(root / path)
+        else:
+            # 持ち越し entry → 前回値を引き継ぐ（現内容を「索引済み」と詐称しない）
+            h = prev_checksums.get(path)
+            if h is None:
+                h = calculate_file_hash(root / path)
         if h is not None:
             checksums[path] = h
     return checksums
@@ -475,8 +496,11 @@ def run_merge(store_dir, key, project_root, *, delete_only=False):
             "warnings": warnings,
         }
 
-    # 5. OK: checksums 更新（最終 docs から再計算）・work 削除（§6.5）
-    new_checksums = compute_checksums_for_docs(docs, project_root)
+    # 5. OK: checksums 更新（§6.5）。今回充填した doc のみ現内容ハッシュ、持ち越しは前回値を
+    #    引き継ぐ（errored-updated の stale 固定を防ぐ / Issue #22 レビュー対応）。
+    new_checksums = compute_checksums_for_docs(
+        docs, project_root, completed_paths=set(completed.keys()), prev_checksums=prev_checksums
+    )
     if not write_checksums_yaml(
         new_checksums, checksums_file, header_comment=f"ToC checksums for key: {key}"
     ):

--- a/scripts/toc_store.py
+++ b/scripts/toc_store.py
@@ -427,7 +427,15 @@ def work_status(store_dir, project_root):
             pending (list[str]): 未充填 entry_file（project-root 相対）。toc-updater 起動対象
             completed (int): status == 'completed' の件数
             error_pending (list[dict]): [{entry_file, error_message}]（充填試行済みエラー）
-            next_action (str): 'prepare'（work-dir なし）/ 'fill'（pending あり）/ 'merge'（pending なし）
+            next_action (str):
+                'prepare' — work-dir なし
+                'fill'    — 充填可能な pending あり
+                'blocked' — 充填可能 pending は無いが error_pending あり。**silent merge 禁止**。
+                            merge は completed のみ採用し成功時に .toc_work を削除するため、
+                            errored doc は今回 ToC から脱落し、**updated doc は現内容 checksum が
+                            書かれて次回も再索引されず stale 固定**になる。上位層が
+                            retry / 承知で merge / 中止 を選ぶ（Issue #22 レビュー対応）。
+                'merge'   — pending も error_pending も無い（全 completed / 空）
     """
     store_dir = Path(store_dir)
     work_dir = store_dir / WORK_DIRNAME
@@ -465,8 +473,16 @@ def work_status(store_dir, project_root):
         else:
             result["pending"].append(rel)
 
-    # 継続判定: 充填可能な pending が残れば fill、無ければ（completed/error/空のみ）merge。
-    result["next_action"] = "fill" if result["pending"] else "merge"
+    # 継続判定:
+    #   pending あり          → fill
+    #   pending 無 + error あり → blocked（silent merge せず上位層が判断。脱落/stale 防止）
+    #   どちらも無し           → merge
+    if result["pending"]:
+        result["next_action"] = "fill"
+    elif result["error_pending"]:
+        result["next_action"] = "blocked"
+    else:
+        result["next_action"] = "merge"
     return result
 
 

--- a/skills/index-docs/SKILL.md
+++ b/skills/index-docs/SKILL.md
@@ -68,11 +68,12 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/toc_store.py --key "{key}" --work-status  
 
 stdout の JSON から `next_action` / `pending` / `completed` / `error_pending` / `has_work_dir` を読み、`next_action` に従う:
 
-| `next_action` | 意味                                          | 動作                                                                     |
-| ------------- | --------------------------------------------- | ------------------------------------------------------------------------ |
-| `prepare`     | `.toc_work/` なし                             | 通常どおり Step 1（prepare）から開始する                                 |
-| `fill`        | 充填可能な pending あり                       | `prepare_toc.py` を **再実行せず** Step 2（充填）から再開し merge へ進む |
-| `merge`       | pending なし（全 completed / error 記録済み） | Step 3（merge）へ直行する                                                |
+| `next_action` | 意味                                            | 動作                                                          |
+| ------------- | ----------------------------------------------- | ------------------------------------------------------------- |
+| `prepare`     | `.toc_work/` なし                               | 通常どおり Step 1（prepare）から開始する                      |
+| `fill`        | 充填可能な pending あり                         | `prepare_toc.py` を **再実行せず** Step 2（充填）から再開する |
+| `blocked`     | 充填可能 pending は無いが `error_pending` あり  | **silent merge 禁止。Step 2.5（エラー対応）** へ              |
+| `merge`       | pending も error_pending も無い（全 completed） | Step 3（merge）へ直行する                                     |
 
 > `store_dir` の特定や `.toc_work/` の有無・pending 列挙を AI が手で導出・走査しない。`--work-status` が `pending`（project-root 相対の entry_file 一覧）まで返すため、Step 2 はそのリストをそのまま使う。
 
@@ -157,9 +158,24 @@ Agent(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_
 
 > 単体モードでは toc-updater 側が `write_pending.py --all` を使う（`--key all` はユーザー任意指定として reject されるため）。`entry_file` は project-root-relative で渡す。
 
-各バッチ完了後、**`toc_store.py --work-status` を再実行して残 `pending` を取得**し（AI が手で再走査しない）、簡潔な進捗（例: "Batch 2/4 complete, 10 remaining"）のみ出力する。`pending` が空（`next_action: merge`）になったら Step 3 へ。
+各バッチ完了後、**`toc_store.py --work-status` を再実行**し（AI が手で再走査しない）、簡潔な進捗（例: "Batch 2/4 complete, 10 remaining"）のみ出力する。`next_action` が `merge` になったら Step 3 へ、`blocked` なら Step 2.5 へ。
 
-> **error_pending の扱い**: 充填に失敗した entry は `write_error_yaml` が `status: pending` + `error_message` を記録する。`--work-status` はこれを `error_pending` に分類し `pending` から除外するため、**同一 run 内では再試行されない**（無限ループ防止）。これらは merge では completed のみ採用され除外される（Step 3）。再試行したい場合は、元文書を修正のうえ `toc_store.py --key {key} --clean-work-dir` で work-dir を破棄してから `index-docs` を再実行（再 prepare）する。`merge_toc.py` 成功時は `.toc_work/` ごと削除されるため、次回は自然に再 prepare される。
+### Step 2.5: 充填エラーの対応（`next_action: blocked` 時のみ）
+
+`pending` は空だが `error_pending`（充填に失敗した entry）が残る状態。**そのまま merge してはならない。** merge は completed のみ採用し成功時に `.toc_work/` を削除するため:
+
+- errored doc は **今回の ToC から脱落**する。
+- とくに **updated（既存文書の改訂）が errored の場合**、merge が現内容の checksum を書くため、**次回 prepare で「変更なし」と誤判定され、改訂が二度と索引されない（stale 固定）**。
+
+したがって `error_pending` を握りつぶさず、`error_pending` の各 `entry_file` と `error_message` を提示し、AskUserQuestion で対応を確認する:
+
+| 選択             | 動作                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| **再試行**       | `error_pending` の `entry_file` に対し toc-updater を再起動（transient 失敗の救済）→ Step 2 へ戻る     |
+| **承知で merge** | 失敗分の脱落（および updated の stale 化）を承知のうえ Step 3（merge）。完了レポートで脱落 path を明示 |
+| **中止**         | merge せず終了。元文書を修正して再実行を促す                                                           |
+
+> 失敗が恒常的（元文書の問題）なら「再試行」は無限に成功しない。その場合は元文書を直してから再実行するか、「承知で merge」を選ぶ。
 
 ### Step 3: merge（統合 + 削除反映 / §6.5）
 

--- a/skills/index-docs/SKILL.md
+++ b/skills/index-docs/SKILL.md
@@ -109,7 +109,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/prepare_toc.py --all
 `prepare_toc.py` は paths 検証（traversal / 絶対パス / 不在 / 非 Markdown を reject。root 外を指す symlink は default-deny で確認待ちにする）と desired-state 差分検出を行い、added + updated 分の pending YAML を `store_dir/.toc_work/` に生成する。stdout の単一 JSON から以下を読む:
 
 - `status`（`ok` / `partial` / `needs_confirmation` / `error`）/ `error_code`
-- `toc_path`（→ `store_dir` と `.toc_work/` の特定に使う）
+- `toc_path`（生成された toc.yaml の project-relative パス。報告用。`.toc_work/` の所在・pending は AI が手で導出せず Step 2 で `--work-status` から取得する）
 - `counts.added` / `counts.updated` / `counts.deleted` / `counts.unchanged`
 - `rejected_paths`（reject された path と理由）/ `warnings`
 - `external_pending`（`status == needs_confirmation` 時。root 外を指す未承認 symlink の `[{symlink, resolved, affected_count}]`）
@@ -157,7 +157,9 @@ Agent(subagent_type: doc-advisor:toc-updater, prompt: "all (single mode), entry_
 
 > 単体モードでは toc-updater 側が `write_pending.py --all` を使う（`--key all` はユーザー任意指定として reject されるため）。`entry_file` は project-root-relative で渡す。
 
-各バッチ完了後、**`toc_store.py --work-status` を再実行して残 `pending` を取得**し（AI が手で再走査しない）、簡潔な進捗（例: "Batch 2/4 complete, 10 remaining"）のみ出力する。`pending` が空（`next_action: merge`）になったら Step 3 へ。エラー記録済み pending は `error_pending` に分類され充填対象から外れる。
+各バッチ完了後、**`toc_store.py --work-status` を再実行して残 `pending` を取得**し（AI が手で再走査しない）、簡潔な進捗（例: "Batch 2/4 complete, 10 remaining"）のみ出力する。`pending` が空（`next_action: merge`）になったら Step 3 へ。
+
+> **error_pending の扱い**: 充填に失敗した entry は `write_error_yaml` が `status: pending` + `error_message` を記録する。`--work-status` はこれを `error_pending` に分類し `pending` から除外するため、**同一 run 内では再試行されない**（無限ループ防止）。これらは merge では completed のみ採用され除外される（Step 3）。再試行したい場合は、元文書を修正のうえ `toc_store.py --key {key} --clean-work-dir` で work-dir を破棄してから `index-docs` を再実行（再 prepare）する。`merge_toc.py` 成功時は `.toc_work/` ごと削除されるため、次回は自然に再 prepare される。
 
 ### Step 3: merge（統合 + 削除反映 / §6.5）
 

--- a/tests/scripts/test_merge_toc.py
+++ b/tests/scripts/test_merge_toc.py
@@ -41,6 +41,7 @@ from merge_toc import (
     load_completed_pendings,
     detect_deleted,
     load_deleted_sidecar,
+    compute_checksums_for_docs,
 )
 from toc_store import (
     resolve_store_dir,
@@ -685,6 +686,56 @@ class TestCoordinationFlow(MergeTestBase):
         content = self._toc_path("rules").read_text(encoding='utf-8')
         self.assertNotIn("docs/b.md", content)
         self.assertIn("docs/a.md", content)
+
+
+class TestComputeChecksumsCarryForward(unittest.TestCase):
+    """compute_checksums_for_docs: completed のみ現内容、持ち越しは前回値引き継ぎ（Issue #22）。"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.root = Path(self.tmpdir)
+        (self.root / "docs").mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, rel, content):
+        p = self.root / rel
+        p.write_text(content, encoding="utf-8")
+        return calculate_file_hash(p)
+
+    def test_completed_uses_current_hash(self):
+        cur = self._write("docs/a.md", "new content")
+        docs = {"docs/a.md": {"title": "A"}}
+        cs = compute_checksums_for_docs(
+            docs, self.root, completed_paths={"docs/a.md"}, prev_checksums={"docs/a.md": "OLD"}
+        )
+        self.assertEqual(cs["docs/a.md"], cur)  # 充填済み→現内容
+
+    def test_carried_over_keeps_prev_not_current(self):
+        # 改訂されたが充填失敗（completed でない）→ 現内容ではなく前回(旧)値を残す。
+        self._write("docs/a.md", "MODIFIED content")
+        docs = {"docs/a.md": {"title": "A(old)"}}
+        cs = compute_checksums_for_docs(
+            docs, self.root, completed_paths=set(), prev_checksums={"docs/a.md": "OLDHASH"}
+        )
+        # 現内容ハッシュ（MODIFIED）を詐称せず、旧値を残す → 次回 prepare が「変更あり」と検知
+        self.assertEqual(cs["docs/a.md"], "OLDHASH")
+
+    def test_carried_over_without_prev_falls_back_to_current(self):
+        cur = self._write("docs/a.md", "x")
+        docs = {"docs/a.md": {"title": "A"}}
+        cs = compute_checksums_for_docs(
+            docs, self.root, completed_paths=set(), prev_checksums={}
+        )
+        self.assertEqual(cs["docs/a.md"], cur)
+
+    def test_legacy_none_completed_all_current(self):
+        # 旧 API 互換: completed_paths=None なら全件現内容（後方互換）。
+        cur = self._write("docs/a.md", "y")
+        docs = {"docs/a.md": {"title": "A"}}
+        cs = compute_checksums_for_docs(docs, self.root)
+        self.assertEqual(cs["docs/a.md"], cur)
 
 
 if __name__ == '__main__':

--- a/tests/scripts/test_toc_store.py
+++ b/tests/scripts/test_toc_store.py
@@ -352,7 +352,8 @@ class TestWorkStatus(unittest.TestCase):
         self.assertEqual(r["completed"], 2)
         self.assertEqual(r["pending"], [])
 
-    def test_error_pending_classified_and_not_blocking_merge(self):
+    def test_error_pending_blocks_merge(self):
+        # 失敗 pending が残るときは silent merge せず blocked を返す（脱落/stale 防止）。
         self._write_entry("aaa.yaml", status="completed")
         self._write_entry("err.yaml", status="pending",
                           error_message="extraction failed")
@@ -361,8 +362,16 @@ class TestWorkStatus(unittest.TestCase):
         self.assertEqual(len(r["error_pending"]), 1)
         self.assertEqual(r["error_pending"][0]["entry_file"], "store/.toc_work/err.yaml")
         self.assertEqual(r["pending"], [])
-        # 充填可能 pending が無いので merge へ（error は試行済み）
-        self.assertEqual(r["next_action"], "merge")
+        self.assertEqual(r["next_action"], "blocked")
+
+    def test_pending_takes_precedence_over_error(self):
+        # 充填可能 pending があれば（error が併存しても）fill を優先。
+        self._write_entry("aaa.yaml", status="pending")
+        self._write_entry("err.yaml", status="pending", error_message="boom")
+        r = work_status(self.store_dir, self.root)
+        self.assertEqual(r["next_action"], "fill")
+        self.assertEqual(r["pending"], ["store/.toc_work/aaa.yaml"])
+        self.assertEqual(len(r["error_pending"]), 1)
 
     def test_hidden_files_excluded(self):
         self.work_dir.mkdir(parents=True, exist_ok=True)

--- a/workflows/toc_orchestrator.md
+++ b/workflows/toc_orchestrator.md
@@ -65,15 +65,23 @@ key's `store_dir`, so multiple keys never collide.
 
 ### Phase 0: Continuation determination (per key, DES-005 §6.6)
 
-Before preparing, decide whether to resume an interrupted run for the target key. Determine the
-key's `store_dir` (from a prior `prepare`/`merge` JSON, or by resolving the key once) and check
-`store_dir/.toc_work/` with `test -d`.
+Before preparing, decide whether to resume an interrupted run. **Do not derive `store_dir`, run
+`test -d`, or read `_meta.status` by hand** — run the deterministic helper and follow `next_action`
+(Issue #22):
 
-| Condition                                                      | Action                                                                                                |
-| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `store_dir/.toc_work/` exists with pending (`status: pending`) | Do **not** re-run `prepare_toc.py`. Resume parallel fill (Phase 2) from remaining pending, then merge |
-| `store_dir/.toc_work/` exists with all `completed`             | Already filled. Go directly to merge (Phase 3)                                                        |
-| `store_dir/.toc_work/` does not exist                          | Normal start from Phase 1 (prepare)                                                                   |
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/toc_store.py --key "{key}" --work-status   # single mode: --all
+```
+
+It emits JSON with `next_action` / `pending` (project-root-relative entry_files) / `completed` /
+`error_pending` / `has_work_dir`.
+
+| `next_action` | Meaning                                                 | Action                                                      |
+| ------------- | ------------------------------------------------------- | ----------------------------------------------------------- |
+| `prepare`     | no `.toc_work/`                                         | Normal start from Phase 1 (prepare)                         |
+| `fill`        | fillable pending exist                                  | Do **not** re-run `prepare_toc.py`. Resume Phase 2 (fill)   |
+| `blocked`     | no fillable pending but `error_pending` exist           | **Do not silently merge.** Go to Phase 2.5 (error handling) |
+| `merge`       | no pending and no error_pending (all completed / empty) | Go directly to Phase 3 (merge)                              |
 
 > To discard `.toc_work/` and re-prepare from scratch (e.g. corrupted pending), use
 > `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/toc_store.py --key "{key}" --clean-work-dir` (single mode: `--all`).
@@ -140,24 +148,33 @@ unapproved external paths are then dropped with warnings and processing continue
 >   `store_dir/.toc_work/` with completed entries is preserved; Phase 0 detects it and
 >   resumes from pending files only (per-key continuation)
 
-**Note**: Do not use `xargs` for file listing — it fails with long Japanese filenames.
-Use `ls .toc_work/*.yaml` or `while read` loops instead.
+**Note**: Do not hand-list or hand-filter the work dir. Get the pending entry_files from
+`toc_store.py --work-status` (`pending` field) — never `ls .toc_work/*.yaml` + `_meta.status`
+reading by the AI.
 
 ```
-1. Identify pending-status files from store_dir/.toc_work/*.yaml
-   (exclude hidden `.`-prefixed files; only those with _meta.status: pending)
+1. Take `pending` (project-root-relative entry_files) from `--work-status`.
     ↓
-2. If no pending files → Go to Phase 3 (merge)
-    ↓
-3. Use max_workers = 5 (default).
+2. Use max_workers = 5 (default).
    CRITICAL: Launch up to N Agent tool calls in a SINGLE assistant message.
    Do NOT launch them one at a time in separate messages — this defeats parallelism.
    Pass key (or `all` for single mode) and the entry_file (project-root-relative).
     ↓
-4. Wait for all N tasks to complete; output a brief progress summary
+3. Wait for all N tasks to complete; output a brief progress summary.
     ↓
-5. If pending files remain → Return to step 1
+4. Re-run `--work-status`. If `next_action: fill` → return to step 1;
+   `merge` → Phase 3; `blocked` → Phase 2.5 (error handling).
 ```
+
+### Phase 2.5: Fill-error handling (`next_action: blocked` only)
+
+`pending` is empty but `error_pending` (entries that failed to fill) remain. **Do not merge silently:**
+merge keeps only completed docs and removes `.toc_work/` on success, so errored docs drop out of this
+run's ToC — and an errored **updated** doc gets a current-content checksum written, so the next prepare
+sees "unchanged" and never re-indexes it (silent staleness). Present each `error_pending` entry_file +
+`error_message` and ask (AskUserQuestion): **retry** the error_pending entry_files (re-launch toc-updater
+→ back to step 1), **merge anyway** (accept the dropped docs; report them in the completion summary), or
+**abort** (fix the source documents and re-run).
 
 ### Phase 3: Merge (integration + deletion reflection, DES-005 §6.5)
 

--- a/workflows/toc_update_workflow.md
+++ b/workflows/toc_update_workflow.md
@@ -80,17 +80,19 @@ Phase 3: merge — integration + deletion reflection (merge_toc.py)
 
 ## Phase 0: Continuation determination (Orchestrator)
 
-Check the target key's `store_dir/.toc_work/`:
+Run the deterministic helper and follow `next_action` — **do not `test -d` or read `_meta.status`
+by hand** (Issue #22):
 
 ```bash
-test -d "{store_dir}/.toc_work" && echo "EXISTS" || echo "NOT_EXISTS"
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/toc_store.py --key "{key}" --work-status   # single mode: --all
 ```
 
-| Condition                            | Processing                                                                   |
-| ------------------------------------ | ---------------------------------------------------------------------------- |
-| `.toc_work/` exists + pending remain | Continuation: resume Phase 2 from existing pending YAMLs (do not re-prepare) |
-| `.toc_work/` exists + all completed  | Go directly to merge (Phase 3)                                               |
-| `.toc_work/` does not exist          | Normal start: Phase 1 (prepare)                                              |
+| `next_action` | Processing                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------ |
+| `prepare`     | Normal start: Phase 1 (prepare)                                                                  |
+| `fill`        | Continuation: resume Phase 2 from `pending` entry_files (do not re-prepare)                      |
+| `blocked`     | `error_pending` remain — **do not silently merge**; handle errors (retry / merge-anyway / abort) |
+| `merge`       | Go directly to merge (Phase 3)                                                                   |
 
 > To discard a corrupted `.toc_work/` and re-prepare from scratch:
 > `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/toc_store.py --key "{key}" --clean-work-dir` (single mode: `--all`).
@@ -132,8 +134,10 @@ added/updated > 0 → Phase 2).
 
 ### Step 2.1: Identify pending YAMLs
 
-Read `store_dir/.toc_work/*.yaml` (exclude hidden `.`-prefixed files) and identify entries with
-`_meta.status: pending`.
+Take the `pending` list (project-root-relative entry_files) from `toc_store.py --work-status`.
+**Do not hand-list `store_dir/.toc_work/*.yaml` or read `_meta.status` by hand.** After each batch,
+re-run `--work-status`: `fill` → continue, `merge` → Phase 3, `blocked` → fill-error handling
+(error_pending must not be silently merged — see toc_orchestrator.md Phase 2.5).
 
 ### Step 2.2: Launch custom Agents in parallel
 


### PR DESCRIPTION
## 概要

Issue #22（A 群: index-docs の決定論 script 化、PR #23 でマージ済）への**外部レビュー対応**。errored pending の取り扱いと、配布 workflow / merge の checksum 挙動を是正する。

## レビュー指摘と対応

### High: errored pending が silent merge で脱落 / updated は stale 固定

- 機構: `merge_toc` は completed のみ採用し成功時に `.toc_work/` 削除＋**全 docs に現内容 checksum**を書く。errored-updated doc は旧 entry が残ったまま現内容 checksum が書かれ、次回 prepare が「変更なし」と誤判定 → 改訂が二度と索引されない。
- 対応（2 層）:
  1. `work_status`: 充填可能 pending 無 + `error_pending` 有 → `next_action="blocked"` を返し **silent merge を禁止**。SKILL/workflow は提示して retry / 承知で merge / 中止 を選ばせる。
  2. `compute_checksums_for_docs`: **今回充填した doc のみ現内容ハッシュ／持ち越し entry は前回 checksum を引き継ぐ**。→ errored-updated は旧値が残り次回再充填され、**恒久 stale 固定を根治**。

### Medium: 配布 workflow が手列挙のままで SKILL と矛盾

- `workflows/toc_orchestrator.md` / `toc_update_workflow.md` の Phase 0/2 を `test -d`・`ls .toc_work`・`_meta.status` 手読みから **`toc_store.py --work-status` 駆動**へ更新。`blocked`（Phase 2.5）も明記。runtime Read 配布物のため SKILL と一致させる。

## 変更内容

- `scripts/toc_store.py`: `work_status` の `next_action` に `blocked` を追加。
- `scripts/merge_toc.py`: `compute_checksums_for_docs(docs, project_root, completed_paths, prev_checksums)` で持ち越し checksum を引き継ぐ。
- `skills/index-docs/SKILL.md`: Step 0 表に `blocked`、Step 2.5（エラー対応）、Step 1 の残骸除去。
- `workflows/toc_orchestrator.md` / `workflows/toc_update_workflow.md`: `--work-status` 駆動・Phase 2.5 へ更新。
- `tests/scripts/test_toc_store.py` / `test_merge_toc.py`: blocked・checksum carry-forward の単体を追加。

## テスト

- [x] `python3 -m unittest discover -s tests -p 'test_*.py'` 全 411 件 PASS（回帰なし）
- [x] 正常系 merge（全 completed）は従来と同一ハッシュを確認
- [x] `dprint check`（SKILL / workflows）

## 受け入れ基準（#22 A 群レビュー対応分）

- [x] errored pending を silent merge しない（blocked）
- [x] errored-updated の stale 固定を根治（checksum 引き継ぎ）
- [x] 配布 workflow を `--work-status` と整合
- [x] 単体テスト追加

Part of #22 — A 群（本体 index-docs）のレビュー対応。外部 golden harness の script 化（B 群）は別途（外部 gitignore のため本 PR 対象外）。
