### PR TITLE
[Fix] query-worker が稀に絶対パスを返す問題への相対パス使用指示の追加

### DIFF
--- a/plugins/doc-advisor/agents/query-worker.md
+++ b/plugins/doc-advisor/agents/query-worker.md
@@ -110,6 +110,8 @@ Required documents:
 Required documents:
 ```
 
+**[MANDATORY] パスは相対パスで返す**: 各行のパスは必ず ToC（`get_toc.py` の出力）から得た **相対パス**（`docs/...` 等）をそのまま記載する。`Read` ツールが表示する **絶対パス**（`/Users/...` 等）に置き換えてはならない。呼び出し元（dispatcher / `/forge:query-db-specs` 等）は相対パスを期待しており、絶対パスはファイルアクセス・表示を壊す。
+
 ### 形式 B: クエリエラー（`Query error:`）
 
 ToC 未生成（`TOC_NOT_FOUND`）・予約 key 衝突（`KEY_RESERVED`）の場合はこの形式で返す。


### PR DESCRIPTION
Closes #35

## 概要

- `doc-advisor:query-worker` が `Required documents:` に稀（20回中1回 ≒ 5%）に絶対パスを返す問題を緩和する。

## 背景

- `get_toc.py` / ToC yaml は相対パスで格納・出力しているが、worker が候補確認に使う `Read` ツールの出力ヘッダには絶対パスが含まれる。
- `query-worker.md` の Output Format に「相対パスを使え」という明示指示がなく、worker が稀に `Read` 由来の絶対パスを出力に転記していた。
- 呼び出し元（dispatcher / `/forge:query-db-specs` 等）は相対パスを前提としており、絶対パス混入でファイルアクセス・表示が壊れうる。

## やったこと

`plugins/doc-advisor/agents/query-worker.md` の **Output Format 形式 A**（出力地点）に [MANDATORY] でパスの出所を明示:

- 「ToC（`get_toc.py`）由来の相対パスをそのまま使い、`Read` が表示する絶対パスに置換しない」旨。
- バグは出力構築時の転記の選択であり、その選択をする規範箇所（出力フォーマット定義）に1箇所だけ規約を置く方針とした。

## やらないこと（このプルリクエストのスコープ外とすること）

- Step: 最終判定 や orchestrator（`query_toc_orchestrator.md`）には追記しない。絶対パスの混入は `Read` 時点では避けられず（本文確認に `Read` が必須）、バグは出力構築時の転記選択のため、規約は出力地点の1箇所で足りる（重複記述による文書肥大化を避ける）。
- 本修正はプロンプト指示による **確率的緩和** であり、非決定的な LLM 挙動の性質上、再発率の低減は期待できるが **完全排除は保証しない**。
- 確定修正が必要な場合は、worker 戻り値を script で相対パス正規化する決定論的後処理（戻り契約の変更を伴う別スコープ）が将来候補。

## レビュー観点

- 追記した 1 箇所（形式 A）が worker の挙動（最終リストへの相対パス転記）を正しく拘束しているか。
- 確率的緩和という限界の記述が妥当か。

## レビューレベル

- ~~Lv0: まったく見ないでAcceptする~~
- Lv1: ぱっとみて違和感がないかチェックしてAcceptする
- ~~Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする~~
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~
