### PR TITLE
fix: 上位層が渡す --dirs-json / --exclude-json を受け付け、引数契約を設計書へ移す

### DIFF
--- a/docs/rules/implementation_guidelines.md
+++ b/docs/rules/implementation_guidelines.md
@@ -1,15 +1,15 @@
 ---
 type: doc-advisor
 title: Implementation Guidelines
-purpose: "Defines the rules for implementing plugin scripts and SKILL.md: language selection, mandatory test scope and placement, the inline-script ban, design doc sync, and the ban on editing version files."
+purpose: "Defines the rules for implementing plugin scripts and SKILL.md: language selection, mandatory tests, the inline-script ban, design doc sync, distributed interface changes, and version file edits."
 content_details:
   - Criteria for choosing Python or Bash by workload (Python for data transformation and YAML/JSON handling, Bash for invoking external commands)
   - Python scripts use the standard library only; external dependencies are forbidden
   - Tests are mandatory for .py files under scripts/; SKILL.md is exempt because AI behavior is hard to test automatically; .claude/ is out of scope
   - Test placement under tests/scripts, tests/skills, tests/integration and the test_{module}.py naming convention
-  - Why inline scripts are banned in SKILL.md (the AI rewrites or omits the code and fails) and the correct pattern of calling a standalone script
-  - Script placement (skills/{skill}/ for skill-specific, scripts/ for plugin-wide) referenced via CLAUDE_PLUGIN_ROOT or CLAUDE_SKILL_DIR
+  - Why inline scripts are banned in SKILL.md (the AI rewrites or omits the code and fails), the correct pattern of calling a standalone script, and where scripts live (skills/{skill}/ versus scripts/) referenced via CLAUDE_PLUGIN_ROOT or CLAUDE_SKILL_DIR
   - Design documents are updated in the same PR as the code, and ADRs live under docs/specs/base/design/
+  - Distributed interfaces are contracts with upper layers - grep callers in the other repository before removing an argument, read git diff after a full Write overwrite, and name each dropped argument in the plan
   - Unused code is deleted outright, including its tests, rather than left as deprecation markers or commented-out blocks
   - Never apply a rigid token parser to input the AI is meant to interpret; fill gaps with AskUserQuestion instead
   - Ordinary feature/fix/refactor PRs must not edit plugin.json version, README version lines, CHANGELOG entries, or git tags
@@ -17,6 +17,7 @@ applicable_tasks:
   - Choosing the implementation language for a new script
   - Adding tests and deciding where to place them
   - Writing a script invocation from SKILL.md
+  - Changing or removing a SKILL argument or a distributed script CLI
   - Updating design documents and ADRs alongside code
   - Judging whether a version or CHANGELOG edit is allowed in the current PR
   - Removing code that is no longer used
@@ -27,11 +28,11 @@ keywords:
   - test_{module}.py
   - CLAUDE_PLUGIN_ROOT
   - design doc maintenance
+  - backward compatibility
   - CHANGELOG
   - plugin.json
   - ADR
-  - no external dependencies
-body_hash: sha256:968583e1c640d25b73ab06a95c4eaf4c0d1e0fb79d595b4528920a41f3d6678c
+body_hash: sha256:88250c28b0aca2764a12470de89cc98b03d991d9d45970a853e6ff50f3029e32
 ---
 
 # 実装ガイドライン
@@ -135,6 +136,30 @@ SKILL.md からの参照には `${CLAUDE_SKILL_DIR}` または `${CLAUDE_PLUGIN_
 - ADR の配置先: `docs/specs/base/design/ADR-{NNN}_{topic}.md`
 - 設計書の更新は **コードと同一 PR** で行うのが原則
 - 大きな構造変更は専用の `DES-{NNN}` 設計書を立て、`README.md` / `CLAUDE.md` の説明とも整合させる
+
+---
+
+## 配布インターフェースを壊す前に呼び出し元を確認する [MANDATORY]
+
+配布物（SKILL の引数・配布 script の CLI）は**上位層との契約**である。変更・削除の前に呼び出し元を横断 grep して確認する。
+
+```bash
+# 呼び出し元は別リポジトリ（bw-cc-plugins の forge / anvil）にあるため、
+# このリポジトリ内の grep では見つからない
+grep -rn "doc-advisor:index-docs" <bw-cc-plugins のチェックアウト>/plugins/
+```
+
+- 引数の**追加**は既存の呼び出し元を壊さない。**削除・改名、および受け付ける形を減らすこと**が壊す
+- 上位層は各 SKILL を **1 回だけ**呼び、引数を組み替えず、失敗しても再試行しない。壊れると**上位層には理由が分からないまま機能が止まる**
+- 引数仕様の正本は設計書に置く（配布物だけを正本にすると、書き換えで契約が消えても突き合わせる相手がいない）。契約の所在は DES-005 / DES-008 の該当節
+
+### 全面上書きしたら差分を読む
+
+配布物を `Write` で全面上書きすると**何が消えたかが画面に出ない**。上書き後に `git diff` を読み、引数表・オプション名の行が消えていないかを確認する。`Edit` なら差分が目に入るが、`Write` は見えない。
+
+### 後方互換を壊す変更は計画に個別項目として書く
+
+「オプションを整理する」「引数を最小にする」等の包括表現の下に後方互換の破壊を含めてはならない。**どの引数を削るかを名指しで書き、承認を得る。** 計画に書かれていない破壊は承認されていない。
 
 ---
 

--- a/docs/specs/base/design/DES-005_toc_generation_flow.md
+++ b/docs/specs/base/design/DES-005_toc_generation_flow.md
@@ -1,13 +1,13 @@
 ---
 type: doc-advisor
 title: DES-005 key + path ToC Provider Design
-purpose: Defines the design for the generic ToC provider keyed by an opaque key and project-root-relative paths, covering path validation, desired-state sync, transcription, and merge.
+purpose: Defines the generic ToC provider keyed by an opaque key and project-root-relative paths, covering path validation, desired-state sync, transcription, merge, and the SKILL argument contract.
 content_details:
   - index_docs.py wrapper - the single entry point AI calls; stage detection, plumbing, and an action payload
   - action values - dispatch / wait / confirm / done / error, with agents[].prompt ready to pass through
   - Core CLIs stay but SKILLs must not call them (a second entry point makes state diverge)
-  - Withdrawal vs breakage - a missing frontmatter dir is allowed, an unreadable one is an error (the loss is speed, not correctness)
-  - Retry of a failed fill clears the error state first so the normal claim lease applies
+  - SKILL argument contract - the spec, not SKILL.md, is the source of truth; upper layers pass --dirs-json and a SKILL.md rewrite once deleted it
+  - Withdrawal vs breakage - a missing frontmatter dir is allowed, an unreadable one is an error; a retried fill clears the error state first so the normal claim lease applies
   - store_dir(key) resolution - NFC-normalized slug, 40-char truncation, empty slug falls back to k
   - Path validation flow - ABSOLUTE_PATH / PATH_TRAVERSAL / NOT_FOUND / OUTSIDE_ROOT / NOT_MARKDOWN rejections
   - desired-state diff against .toc_checksums.yaml - a partial paths array deletes the remainder
@@ -16,6 +16,7 @@ content_details:
 applicable_tasks:
   - Implementing or modifying index_docs.py / prepare_toc.py / merge_toc.py
   - Adding a script to the ToC pipeline or changing what the wrapper plumbs
+  - Changing or removing a SKILL argument that upper layers call
   - Changing the JSON output contract or the error_code enum
   - Designing path validation for symlinks that escape the project root
   - Deciding what the AI does versus what a script does in the pipeline
@@ -26,12 +27,12 @@ keywords:
   - resolve_store_dir
   - prepare_toc.py
   - merge_toc.py
-  - fm_to_pending.py
+  - expand_dirs.py
   - desired-state sync
   - reset_error_entries
   - ai_extracted_paths
-  - continuation
-body_hash: sha256:4879533ba9834ccf8c2468095131ac20235519868d0e45196075916c4ebae2f2
+  - "--dirs-json"
+body_hash: sha256:11f83be8a37cbd4efd9286587d3b407a1f29d861bbc6d8ae5cfeee891708fc6e
 ---
 
 # DES-005 key + path ToC Provider 設計書
@@ -178,22 +179,23 @@ store_dir(key) = .claude/.doc-advisor/toc/{slug}/
 
 ### 4.1 モジュール一覧
 
-| モジュール                                                   | 責務                                                                                 | 依存                                                                                        |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `index_docs.py`                                              | **索引パイプラインのラッパー**。AI が呼ぶ唯一の入口。段階判定 → 配管 → `action` 出力 | `expand_dirs`, `prepare_toc`, `merge_toc`, `toc_store`, `frontmatter/fm_to_pending`（§4.5） |
-| `toc_store.py`                                               | key → store_dir 解決、JSON 出力ヘルパ、予約 key 判定                                 | `toc_utils`                                                                                 |
-| `toc_utils.py`                                               | path 検証（traversal + symlink 実体解決）、glob、checksums、YAML I/O                 | 標準ライブラリ                                                                              |
-| `prepare_toc.py`（旧 `create_pending_yaml.py` を改名・転用） | paths 検証 → desired-state 差分検出 → pending 生成、`--dry-run`、JSON 出力           | `toc_store`, `toc_utils`                                                                    |
-| `merge_toc.py`                                               | 充填済み pending を統合 → `toc.yaml` 書き出し（削除反映、原子的書き込み）、JSON 出力 | `toc_store`, `toc_utils`                                                                    |
-| `get_toc.py`（旧 `filter_toc.py` を統合）                    | `toc.yaml` 取得（全体 or `--paths` 縮小抽出）、ranking しない、JSON or YAML 出力     | `toc_store`, `toc_utils`                                                                    |
-| `remove_toc.py`                                              | key 全体削除 / `--paths` 個別エントリ削除、JSON 出力                                 | `toc_store`, `toc_utils`                                                                    |
-| `check_toc.py`                                               | ToC の鮮度判定（read-only）。`metadata` のみ読み `freshness` を JSON 出力（DES-009） | `toc_store`, `toc_utils`                                                                    |
-| `write_pending.py`                                           | toc-updater agent が pending にメタデータ充填（`--key` 対応、doc_type 引数なし）     | `toc_utils`                                                                                 |
-| `validate_toc.py`                                            | `toc.yaml` 検証（doc_type 必須なし、key ストアパス対応）                             | `toc_store`, `toc_utils`                                                                    |
-| `frontmatter/fm_core.py`                                     | フロントマターのパース / 生成、本文抽出・正規化、`body_hash` 計算、スキーマ検証      | 標準ライブラリのみ（`toc_store` / `toc_utils` を import しない）                            |
-| `frontmatter/fm_read.py`                                     | 渡されたパスのフロントマターを読み信頼判定（DES-008 §5.1）→ JSON 出力                | `fm_core`、標準ライブラリのみ（同上）                                                       |
-| `frontmatter/fm_write.py`                                    | メタデータのマージ書き込み、整形実行後の `body_hash` 打刻                            | `fm_core`、標準ライブラリのみ（同上）                                                       |
-| `frontmatter/fm_to_pending.py`                               | 指定ディレクトリ直下の pending を転記で完了化（`status: completed`）、JSON 出力      | `fm_core`、標準ライブラリのみ（同上）                                                       |
+| モジュール                                                   | 責務                                                                                   | 依存                                                                                        |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `index_docs.py`                                              | **索引パイプラインのラッパー**。AI が呼ぶ唯一の入口。段階判定 → 配管 → `action` 出力   | `expand_dirs`, `prepare_toc`, `merge_toc`, `toc_store`, `frontmatter/fm_to_pending`（§4.5） |
+| `toc_store.py`                                               | key → store_dir 解決、JSON 出力ヘルパ、予約 key 判定                                   | `toc_utils`                                                                                 |
+| `toc_utils.py`                                               | path 検証（traversal + symlink 実体解決）、glob、checksums、YAML I/O                   | 標準ライブラリ                                                                              |
+| `expand_dirs.py`                                             | dirs / グロブを rglob 展開して paths 配列へ変換（固定除外・追加除外を適用）、JSON 出力 | `toc_utils`                                                                                 |
+| `prepare_toc.py`（旧 `create_pending_yaml.py` を改名・転用） | paths 検証 → desired-state 差分検出 → pending 生成、`--dry-run`、JSON 出力             | `toc_store`, `toc_utils`                                                                    |
+| `merge_toc.py`                                               | 充填済み pending を統合 → `toc.yaml` 書き出し（削除反映、原子的書き込み）、JSON 出力   | `toc_store`, `toc_utils`                                                                    |
+| `get_toc.py`（旧 `filter_toc.py` を統合）                    | `toc.yaml` 取得（全体 or `--paths` 縮小抽出）、ranking しない、JSON or YAML 出力       | `toc_store`, `toc_utils`                                                                    |
+| `remove_toc.py`                                              | key 全体削除 / `--paths` 個別エントリ削除、JSON 出力                                   | `toc_store`, `toc_utils`                                                                    |
+| `check_toc.py`                                               | ToC の鮮度判定（read-only）。`metadata` のみ読み `freshness` を JSON 出力（DES-009）   | `toc_store`, `toc_utils`                                                                    |
+| `write_pending.py`                                           | toc-updater agent が pending にメタデータ充填（`--key` 対応、doc_type 引数なし）       | `toc_utils`                                                                                 |
+| `validate_toc.py`                                            | `toc.yaml` 検証（doc_type 必須なし、key ストアパス対応）                               | `toc_store`, `toc_utils`                                                                    |
+| `frontmatter/fm_core.py`                                     | フロントマターのパース / 生成、本文抽出・正規化、`body_hash` 計算、スキーマ検証        | 標準ライブラリのみ（`toc_store` / `toc_utils` を import しない）                            |
+| `frontmatter/fm_read.py`                                     | 渡されたパスのフロントマターを読み信頼判定（DES-008 §5.1）→ JSON 出力                  | `fm_core`、標準ライブラリのみ（同上）                                                       |
+| `frontmatter/fm_write.py`                                    | メタデータのマージ書き込み、整形実行後の `body_hash` 打刻                              | `fm_core`、標準ライブラリのみ（同上）                                                       |
+| `frontmatter/fm_to_pending.py`                               | 指定ディレクトリ直下の pending を転記で完了化（`status: completed`）、JSON 出力        | `fm_core`、標準ライブラリのみ（同上）                                                       |
 
 `create_checksums.py` の `--promote-pending` / `--clean-work-dir` 機能は `toc_store.py` に統合し、key 単位で扱う。
 
@@ -205,7 +207,8 @@ store_dir(key) = .claude/.doc-advisor/toc/{slug}/
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `index_docs.py`                | `--key` / `--all` / `--dirs` / `--paths` / `--exclude`（上位層が機械的に渡す JSON 形 `--dirs-json` / `--paths-json` / `--exclude-json` / `--paths-file` も受ける。例外経路のみ `--allow-external` / `--on-fill-error`） |
 | `toc_store.py`                 | `--work-status` / `--claim` / `--reset-error` / `--promote-pending` / `--clean-work-dir`（**保守・障害切り分け用**。通常経路はラッパーが内部で呼ぶ）                                                                    |
-| `prepare_toc.py`               | `--key` / `--paths-json` / `--paths-file` / `--all` / `--dry-run`                                                                                                                                                       |
+| `expand_dirs.py`               | `--dirs-json`（必須）/ `--exclude-json` / `--paths-json` / `--project-root`（すべて JSON 配列。ラッパーが内部で呼ぶ）                                                                                                   |
+| `prepare_toc.py`               | `--key` / `--paths-json` / `--paths-file` / `--all` / `--dry-run` / `--allow-external-json`                                                                                                                             |
 | `merge_toc.py`                 | `--key` / `--all` / `--delete-only`                                                                                                                                                                                     |
 | `get_toc.py`                   | `--key` / `--all` / `--paths`（`--all` / `--key all` は REQ-001 FR-N04-4）                                                                                                                                              |
 | `remove_toc.py`                | `--key` / `--all` / `--paths-json`（`--all` / `--key all` は REQ-001 FR-N04-4）                                                                                                                                         |
@@ -591,16 +594,62 @@ sequenceDiagram
 
 key + path 汎用化（REQ-001 §6.2）に伴い、SKILL / agent を以下のコンポーネントへ一本化する。
 
-| コンポーネント      | 種別                            | 責務                                                                                                                                                                                                                                                                          |
-| ------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `index-docs`        | SKILL（継承型）                 | **`index_docs.py` を呼び、返る `action` に従う**（§4.1.1）。Agent の起動と判断のみを担い、配管はラッパーが行う。`action: done` の `ai_extracted_paths` を提示し、承認された対象のみ `write-frontmatter` へ `--paths-json` で引き渡す（原本は自ら書き換えない / DES-008 §8.2） |
-| `query-docs`        | SKILL（継承型 dispatcher）      | `$ARGUMENTS`・親 context・guidance から検索依頼を構築し `query-worker` を起動。`--key` 省略時は予約 key `all`                                                                                                                                                                 |
-| `check-toc`         | SKILL（継承型）                 | `check_toc.py` を 1 回呼び `freshness` を返す read-only なラッパ。`--key` / `--all` / `--max-age`（DES-009）                                                                                                                                                                  |
-| `write-frontmatter` | SKILL（継承型）                 | 対象文書の本文からメタデータを作成し `fm_write.py` でフロントマターへ書き込む。原本を書き換えるため実行前にユーザ承認を取る（DES-008 §8.1 / §10.1）                                                                                                                           |
-| `query-worker`      | Agent（Read, Grep, Glob, Bash） | `get_toc` を呼び ToC 全エントリ読解・関連判断・`Required documents:` 返却（read-only）                                                                                                                                                                                        |
-| `toc-updater`       | Agent（Read, Bash）             | pending を読み元文書からメタデータ抽出 → `write_pending.py --key` で充填                                                                                                                                                                                                      |
+| コンポーネント      | 種別                            | 責務                                                                                                                                                                                                                                                                     |
+| ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `index-docs`        | SKILL（継承型）                 | **`index_docs.py` を呼び、返る `action` に従う**（§4.1.1）。Agent の起動と判断のみを担い、配管はラッパーが行う。`action: done` の `ai_extracted_paths` を提示し、承認された対象のみ `write-frontmatter` へ `--paths` で引き渡す（原本は自ら書き換えない / DES-008 §8.2） |
+| `query-docs`        | SKILL（継承型 dispatcher）      | `$ARGUMENTS`・親 context・guidance から検索依頼を構築し `query-worker` を起動。`--key` 省略時は予約 key `all`                                                                                                                                                            |
+| `check-toc`         | SKILL（継承型）                 | `check_toc.py` を 1 回呼び `freshness` を返す read-only なラッパ。`--key` / `--all` / `--max-age`（DES-009）                                                                                                                                                             |
+| `write-frontmatter` | SKILL（継承型）                 | 対象文書の本文からメタデータを作成し `fm_write.py` でフロントマターへ書き込む。原本を書き換えるため実行前にユーザ承認を取る（DES-008 §8.1 / §10.1）                                                                                                                      |
+| `query-worker`      | Agent（Read, Grep, Glob, Bash） | `get_toc` を呼び ToC 全エントリ読解・関連判断・`Required documents:` 返却（read-only）                                                                                                                                                                                   |
+| `toc-updater`       | Agent（Read, Bash）             | pending を読み元文書からメタデータ抽出 → `write_pending.py --key` で充填                                                                                                                                                                                                 |
 
 ADR-002 改訂版（継承型 dispatcher + read-only worker 隔離）を `query-docs` / `query-worker` が実装する。orchestrator パターン（Phase 2 並列・中断耐性・continue モード、§6.6）を `index-docs` が用いる。
+
+### 10.1 SKILL の引数契約 [MANDATORY]
+
+**SKILL の引数は上位層との公開インターフェースであり、その正本は本設計書に置く。**
+
+#### なぜ設計書に置くのか
+
+以前は SKILL の引数仕様が `plugins/doc-advisor/skills/*/SKILL.md` にしか存在しなかった。SKILL.md は配布物であり、方式変更のたびに全面書き換えの対象になる。**唯一の正本が書き換え対象そのものだったため、上位層との契約が書き換えで消えても突き合わせる相手がいなかった。**
+
+実際に消えた。ラッパー化（§4.1.1）の際に `index-docs` から `--dirs-json` / `--exclude-json` が落ち、forge の `update-db-rules` / `update-db-specs` / `query-db-rules` / `query-db-specs` が `unrecognized arguments` で失敗した。上位層は再実行も引数の組み替えもしないため、**索引が動かないまま、上位層には理由が分からない**状態になる。
+
+以後、SKILL.md は本節の実装であり、正本ではない。SKILL.md を書き換えたら本節と突き合わせる。
+
+#### 契約（受け付けなければならない引数）
+
+`index-docs`:
+
+| 引数                     | 主な呼び出し元         | 備考                                                              |
+| ------------------------ | ---------------------- | ----------------------------------------------------------------- |
+| `--key <key>`            | 上位層 / 利用者        | `all` は予約語のため任意指定不可                                  |
+| `--dirs <dir>...`        | 人間・AI が手で打つ    | グロブメタ文字可                                                  |
+| `--dirs-json '[...]'`    | **上位層（forge）**    | 設定から解決した配列をそのまま渡す形。`--dirs` と併用可           |
+| `--paths <path>...`      | 人間・AI が手で打つ    | 当該 key の完全な desired state                                   |
+| `--paths-json '[...]'`   | 上位層 / README 記載   | 同上                                                              |
+| `--paths-file <path>`    | 上位層                 | 長大な配列を argv に載せないための形                              |
+| `--exclude <path>...`    | 人間・AI が手で打つ    | `--dirs` 展開時の追加除外                                         |
+| `--exclude-json '[...]'` | **上位層（forge）**    | `--exclude` と併用可                                              |
+| `--all`                  | 利用者                 | 予約 key `all`。対象指定と併用不可                                |
+| `--allow-external ...`   | 利用者（`confirm` 後） | 例外経路のみ（`reason: external_symlink`）                        |
+| `--on-fill-error <mode>` | 利用者（`confirm` 後） | 例外経路のみ（`reason: fill_error`）。`retry` / `merge` / `abort` |
+
+`query-docs`: `--key <key>`（省略時は予約 key `all`）＋ 自然文のタスク記述。
+`check-toc`: `--key <key>` / `--all` / `--max-age <秒>`（必須。DES-009）。
+`write-frontmatter`: DES-008 §8.1 に規定する。
+
+#### 変更規約
+
+| 変更                     | 手順                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 引数を**追加**する       | 本節に追記する。既存の呼び出し元は壊れない                                                                                         |
+| 引数を**削除・改名**する | **後方互換を壊す変更**。呼び出し元を横断 grep で確認し、計画に個別項目として挙げて承認を得てから行う                               |
+| 受け付ける**形**を減らす | 削除と同じ扱い。入口の数を絞ることと、受け付ける引数の形を絞ることは別である（前者は AI の負担を減らすが、後者は呼び出し元を壊す） |
+
+**既知の呼び出し元**（横断 grep の起点。網羅ではない）: bw-cc-plugins の `plugins/forge/skills/{update-db-rules,update-db-specs,query-db-rules,query-db-specs}/SKILL.md`。いずれも各 SKILL を **1 回だけ**呼び、引数を組み替えず、失敗時に再試行しない。
+
+上位層が `--dirs-json` を渡してきた場合、`--dirs` へ書き換えたり要素を並べ替えたりしない（渡された形をそのまま script へ渡す）。
 
 ## 11. ユースケース設計
 
@@ -682,6 +731,11 @@ REQ-001 NFR-N03（`scripts/` テスト必須）に従い、同一 PR でテス�
   - 削除のみ / 対象 0 件 / 全件 unchanged の各冪等経路
   - 充填エラーで `confirm` を返し、`--on-fill-error` の 3 値がそれぞれ機能すること
   - 索引実行が原本のバイト列を変えないこと / 成功時に `.toc_work/` が残らないこと
+- **SKILL 引数契約のテスト対象**（§10.1 / DES-008 §8.1）:
+  - `index_docs.py` / `frontmatter/fm_run.py` が契約の各引数を受け付けること（`unrecognized arguments` にならない）
+  - 各 SKILL.md が契約の各引数を**記載していること**。SKILL.md は配布物であり全面書き換えの対象になるため、記載が消えると AI がその形で呼べなくなる。実装が受け付けるだけでは上位層の呼び出しは通らない
+  - 上位層が渡した JSON 形をそのまま渡す規定が SKILL.md に残っていること
+  - このテストは事故（`--dirs-json` の消失）を実際に検出することを、壊れていた時点のツリーで確認して導入した
 - **統合テスト対象**:
   - `prepare → write_pending → merge` の協調フローで toc.yaml が生成される
   - `remove --key` でストアが削除される
@@ -700,6 +754,7 @@ REQ-001 NFR-N03（`scripts/` テスト必須）に従い、同一 PR でテス�
 | 2026-07-30 | 0.3        | check-toc（DES-009）の追加に伴い、`check_toc.py` を §2.1 レイヤ図・§4.1 モジュール一覧・CLI オプション表へ、`check-toc` を §10 / §11.1 へ追記。§8 の `error_code` 値域に `INVALID_MAX_AGE` / `TOC_READ_ERROR` を追加し、鮮度確認の JSON 契約（`status` 2 値・ToC 不在の扱い）を明記。§13 に鮮度判定のテスト方針を追記                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | 2026-08-03 | 0.4        | フロントマターメタデータ（DES-008）の追加に伴い、転記フェーズを反映。§1 概要と §2.2 依存方向規範を「script 層の転記 → 残りを AI 層が充填」の 2 段へ改め、`fm_core.py` を独立系統の共通ロジックとして明記。§2.1 レイヤ図へ `frontmatter/` 系統を追加し、§4.1 に `frontmatter/` 配下 4 件のモジュール表と CLI オプション表を追記。§6.1 のシーケンスへ `fm_to_pending.py` の転記経路を追記し、§6.6 の再開判定を転記を含む順序へ更新。§9.3 の単体モードシーケンスにも同じ転記経路を追記し、§10 の `index-docs` 責務と `write-frontmatter` SKILL の行を追加。あわせて `formats/toc_format.md` の Language Rule を本文追従へ改訂（DES-008 §4.4）                                                                                                                                                                                                                                                                                                                                                        |
 | 2026-08-03 | 0.5        | AI 抽出結果の書き戻し候補（DES-008 §8.2）の受け渡し経路を反映。§8.1 のスキーマ例と §8.2 の enum 定義表へ `merge_toc.py` 固有フィールド `ai_extracted_paths` を追記し、報告専用であること・`status: ok` 時のみ出力すること・`--delete-only` では常に空配列であることを明記。§10 の `index-docs` は merge 完了後に候補を提示し、承認された対象のみを `write-frontmatter` へ `--paths-json` で引き渡す                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 2026-08-04 | 1.1        | **SKILL の引数契約の正本を本設計書へ移した**（§10.1 新設 / DES-008 §8.1）。1.0 の事故の根本原因は「既存の呼び出し元を確認しなかった」だけではなく、**引数仕様の唯一の正本が SKILL.md（＝全面書き換えの対象そのもの）だったこと**である。設計書に無いため、書き換えで契約が消えても突き合わせる相手が無かった。§4.1 のモジュール一覧と CLI オプション表に欠落していた `expand_dirs.py` を追加し（旧版には行が無く、`--dirs-json` の出所が設計書上どこにも無かった）、`prepare_toc.py` の `--allow-external-json` も補った。あわせて契約の変更規約（追加は自由 / 削除・改名は横断 grep と承認が必要 / 受け付ける形を減らすのは削除と同じ扱い）と既知の呼び出し元を規定。§13 に SKILL 引数契約のテストを追加し、**壊れていた時点のツリーで実際に落ちることを確認**した。§10 の `write-frontmatter` への引き渡しが `--paths-json` と書かれたまま古くなっていた（実際は `--paths`）ため修正                                                                                                            |
 | 2026-08-04 | 1.0        | **上位層との契約を壊していた不具合を修復した**（§4.1.1 に「呼び出し元は 2 種類ある」を新設・§4.1 の CLI 表・§13 のテスト）。0.7 のラッパー化で対象指定を `--dirs` / `--exclude` のみとし、`--dirs-json` / `--exclude-json` を落としたため、これらを渡して **index-docs を 1 回だけ呼ぶ** forge の `update-db-rules` / `update-db-specs` が `unrecognized arguments` で失敗していた。上位層は再実行も引数の組み替えもしないため、索引が動かないまま理由も分からない状態になる。「入口の数を絞る」ことと「受け付ける引数の形を絞る」ことは別であり、後者は呼び出し元を壊すという教訓を規定として残した                                                                                                                                                                                                                                                                                                                                                                                              |
 | 2026-08-04 | 0.9        | Codex レビュー round 3（🟡 major 1 件）を反映。転記モジュールの読み込み失敗の捕捉を `ImportError` から `Exception` 全体へ広げた（§4.1.1 / §13）。構文エラーは `SyntaxError` であり `ImportError` ではないため、捕まえ損ねると traceback で終了し §8.1 の「stdout に単一 JSON」契約を破る。0.8 の時点では「破損が露見する方向なので放置」と判断していたが、silent success を避けることと CLI 契約を満たすことは別の要求であり、後者を落としていた。回帰テストを 3 通り（欠落 / 構文エラー / 依存の破損）へ拡張し、stdout が単一 JSON で stderr に traceback が出ないことを固定した                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | 2026-08-04 | 0.8        | Codex レビュー（🟡 major 2 件）を反映。①転記の「撤回」と「破損」を区別し、`frontmatter/` があるのに転記モジュールを読み込めない場合は `action: error`（`READ_ERROR`）とした（§4.1.1）。`ImportError` の捕捉だけでは破損を撤回と同一視していた。**この判断の根拠は「誤った ToC が出ること」ではない**——破損時も AI 抽出へフォールバックするため `toc.yaml` の内容は正しく、失われるのは転記による高速化だけである。防ぐのは「配布物が壊れたまま性能劣化が黙って続くこと」であり、可用性（AI 抽出では索引できるのに止まる）とのトレードオフを取ったうえで、配布物の部分破損は放置してよい状態ではないと判断した。②充填エラーの再試行を claim/lease に乗せた（ADR-006 追補 2）。`error_pending` をそのまま投入すると `claim_entries` が拒否するため claim が効かず、同じコマンドの再実行で二重投入が起きていた。`toc_store.reset_error_entries()` / `--reset-error` を追加し、error 状態を解除してから通常の claim 経路へ合流させる。§4.1 の CLI 表に `toc_store.py` の行を追加し §13 にテストを追記 |

--- a/docs/specs/base/design/DES-005_toc_generation_flow.md
+++ b/docs/specs/base/design/DES-005_toc_generation_flow.md
@@ -32,7 +32,7 @@ keywords:
   - reset_error_entries
   - ai_extracted_paths
   - "--dirs-json"
-body_hash: sha256:11f83be8a37cbd4efd9286587d3b407a1f29d861bbc6d8ae5cfeee891708fc6e
+body_hash: sha256:b07bc93d88f77b9efea73e723151a248638f21d9cb0e057cbd72ca77030f108a
 ---
 
 # DES-005 key + path ToC Provider 設計書
@@ -647,7 +647,15 @@ ADR-002 改訂版（継承型 dispatcher + read-only worker 隔離）を `query-
 | 引数を**削除・改名**する | **後方互換を壊す変更**。呼び出し元を横断 grep で確認し、計画に個別項目として挙げて承認を得てから行う                               |
 | 受け付ける**形**を減らす | 削除と同じ扱い。入口の数を絞ることと、受け付ける引数の形を絞ることは別である（前者は AI の負担を減らすが、後者は呼び出し元を壊す） |
 
-**既知の呼び出し元**（横断 grep の起点。網羅ではない）: bw-cc-plugins の `plugins/forge/skills/{update-db-rules,update-db-specs,query-db-rules,query-db-specs}/SKILL.md`。いずれも各 SKILL を **1 回だけ**呼び、引数を組み替えず、失敗時に再試行しない。
+**既知の呼び出し元**（横断 grep の起点。網羅ではない）:
+
+| 呼び出し元                                                                                | 渡す形                           |
+| ----------------------------------------------------------------------------------------- | -------------------------------- |
+| bw-cc-plugins `plugins/forge/skills/{update-db-rules,update-db-specs}/SKILL.md`           | `--dirs-json` / `--exclude-json` |
+| bw-cc-plugins `plugins/forge/skills/{query-db-rules,query-db-specs}/SKILL.md`（stale 時） | `--dirs-json` / `--exclude-json` |
+| bw-cc-plugins `.claude/skills/update-forge-toc/SKILL.md`（配布物ではないローカル skill）  | `--key forge-rules --paths-json` |
+
+いずれも各 SKILL を **1 回だけ**呼び、引数を組み替えず、失敗時に再試行しない。**配布プラグインだけを見ると呼び出し元を見落とす**（ローカル skill も上位層である）。
 
 上位層が `--dirs-json` を渡してきた場合、`--dirs` へ書き換えたり要素を並べ替えたりしない（渡された形をそのまま script へ渡す）。
 

--- a/docs/specs/base/design/DES-005_toc_generation_flow.md
+++ b/docs/specs/base/design/DES-005_toc_generation_flow.md
@@ -201,18 +201,18 @@ store_dir(key) = .claude/.doc-advisor/toc/{slug}/
 
 各 script の主な CLI オプション:
 
-| script                         | 主なオプション                                                                                                                                       |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `index_docs.py`                | `--key` / `--all` / `--dirs` / `--paths` / `--paths-json` / `--paths-file` / `--exclude`（例外経路のみ `--allow-external` / `--on-fill-error`）      |
-| `toc_store.py`                 | `--work-status` / `--claim` / `--reset-error` / `--promote-pending` / `--clean-work-dir`（**保守・障害切り分け用**。通常経路はラッパーが内部で呼ぶ） |
-| `prepare_toc.py`               | `--key` / `--paths-json` / `--paths-file` / `--all` / `--dry-run`                                                                                    |
-| `merge_toc.py`                 | `--key` / `--all` / `--delete-only`                                                                                                                  |
-| `get_toc.py`                   | `--key` / `--all` / `--paths`（`--all` / `--key all` は REQ-001 FR-N04-4）                                                                           |
-| `remove_toc.py`                | `--key` / `--all` / `--paths-json`（`--all` / `--key all` は REQ-001 FR-N04-4）                                                                      |
-| `check_toc.py`                 | `--key` / `--all` / `--max-age`（必須）。列挙外の引数は受け取らない（REQ-005 FR-C01-4）                                                              |
-| `frontmatter/fm_to_pending.py` | `--work-dir`                                                                                                                                         |
-| `frontmatter/fm_read.py`       | `--paths-json`                                                                                                                                       |
-| `frontmatter/fm_write.py`      | `--entries-json` / `--format-command`                                                                                                                |
+| script                         | 主なオプション                                                                                                                                                                                                          |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index_docs.py`                | `--key` / `--all` / `--dirs` / `--paths` / `--exclude`（上位層が機械的に渡す JSON 形 `--dirs-json` / `--paths-json` / `--exclude-json` / `--paths-file` も受ける。例外経路のみ `--allow-external` / `--on-fill-error`） |
+| `toc_store.py`                 | `--work-status` / `--claim` / `--reset-error` / `--promote-pending` / `--clean-work-dir`（**保守・障害切り分け用**。通常経路はラッパーが内部で呼ぶ）                                                                    |
+| `prepare_toc.py`               | `--key` / `--paths-json` / `--paths-file` / `--all` / `--dry-run`                                                                                                                                                       |
+| `merge_toc.py`                 | `--key` / `--all` / `--delete-only`                                                                                                                                                                                     |
+| `get_toc.py`                   | `--key` / `--all` / `--paths`（`--all` / `--key all` は REQ-001 FR-N04-4）                                                                                                                                              |
+| `remove_toc.py`                | `--key` / `--all` / `--paths-json`（`--all` / `--key all` は REQ-001 FR-N04-4）                                                                                                                                         |
+| `check_toc.py`                 | `--key` / `--all` / `--max-age`（必須）。列挙外の引数は受け取らない（REQ-005 FR-C01-4）                                                                                                                                 |
+| `frontmatter/fm_to_pending.py` | `--work-dir`                                                                                                                                                                                                            |
+| `frontmatter/fm_read.py`       | `--paths-json`                                                                                                                                                                                                          |
+| `frontmatter/fm_write.py`      | `--entries-json` / `--format-command`                                                                                                                                                                                   |
 
 ### 4.1.1 ラッパー `index_docs.py`（AI が呼ぶ唯一の入口）
 
@@ -226,6 +226,21 @@ store_dir(key) = .claude/.doc-advisor/toc/{slug}/
 #### 呼び出し形
 
 通常経路は 1 コマンドであり、**Agent の完了通知を受けるたびに同じコマンドを再実行する**。初回と再開を呼び出し側が区別しない（状態は `.toc_work/` が持ち、ラッパーが段階を判定する）。ウィンドウ幅・バッチサイズ・リース TTL は呼び出し側の判断材料にならないため **CLI に出さない**（ラッパー内の定数とする）。
+
+#### 呼び出し元は 2 種類ある [MANDATORY]
+
+「オプションをほぼ持たない入口にする」という方針は、**上位層との既存の契約を壊す理由にならない**。対象指定には 2 通りの形を両方受け付ける。
+
+| 呼び出し元               | 形                               | 理由                                                                     |
+| ------------------------ | -------------------------------- | ------------------------------------------------------------------------ |
+| 人間・AI が手で打つ      | `--dirs docs/rules/ docs/specs/` | 短く、引用符のエスケープが要らない                                       |
+| **上位層が機械的に渡す** | `--dirs-json '["docs/rules/"]'`  | 設定ファイルから解決した配列をそのまま渡せる。文字列へ組み立て直させない |
+
+`--exclude` / `--paths` も同様に JSON 形（`--exclude-json` / `--paths-json`）を受け、指定されていれば連結する。
+
+**この規定は実際に壊した経験から来ている。** ラッパー化の際に `--dirs-json` / `--exclude-json` を落として `--dirs` / `--exclude` のみとしたところ、forge の `update-db-rules` / `update-db-specs`（`.doc_structure.yaml` から解決した配列を `--dirs-json` で渡し、**index-docs を 1 回だけ呼ぶ**）が `unrecognized arguments` で失敗するようになった。上位層は再実行も引数の組み替えもしないため、**索引が動かないまま、上位層には理由が分からない**状態になる。
+
+入口の数を絞ることと、受け付ける引数の形を絞ることは別である。前者は AI の負担を減らすが、後者は**呼び出し元を壊す**。
 
 #### `action` の値域
 
@@ -660,6 +675,7 @@ REQ-001 NFR-N03（`scripts/` テスト必須）に従い、同一 PR でテス�
   - claim により同じコマンドの再実行が二重投入しないこと
   - **空きスロットを走行中 Agent 数で数えること**（`window` より `in_flight_groups` が多いとき `available` が負にならず `wait` になる。ADR-006 の回帰固定）
   - 全件転記できたとき Agent を 1 つも返さず `done` へ直行すること
+  - **上位層が渡す JSON 形の対象指定を受けること**（§4.1.1「呼び出し元は 2 種類ある」）: `--dirs-json` / `--exclude-json` / `--paths-json` / `--paths-file` がそれぞれ機能し、繰り返し指定形と併用したとき連結されること。不正な JSON・配列でない値・空文字列を含む配列を `INVALID_PATH` で拒否すること。`--all` との併用時に**どの引数が併用されたかをメッセージで報告する**こと
   - **`frontmatter/` を含まない `scripts/` のコピーで索引が完了すること**（撤回可能性の実証）
   - **`frontmatter/` はあるが読み込めない場合に `action: error` になること**（撤回と破損の区別。破損が `done` として隠れないことの固定）。破損の作り方を 3 通り固定する: モジュールの欠落 / 構文エラー / 依存モジュールの破損。いずれも **stdout が単一 JSON であり stderr に traceback が出ないこと**を確認する（`ImportError` のみを捕捉する実装に戻ると構文エラーで traceback になり失敗する）
   - **再試行が claim/lease に乗ること**: `--on-fill-error retry` の後に同じコマンドを再実行すると `action: wait` になり二重投入しないこと。および retry 後の entry が `error_pending` でなく通常の pending になっていること
@@ -684,6 +700,7 @@ REQ-001 NFR-N03（`scripts/` テスト必須）に従い、同一 PR でテス�
 | 2026-07-30 | 0.3        | check-toc（DES-009）の追加に伴い、`check_toc.py` を §2.1 レイヤ図・§4.1 モジュール一覧・CLI オプション表へ、`check-toc` を §10 / §11.1 へ追記。§8 の `error_code` 値域に `INVALID_MAX_AGE` / `TOC_READ_ERROR` を追加し、鮮度確認の JSON 契約（`status` 2 値・ToC 不在の扱い）を明記。§13 に鮮度判定のテスト方針を追記                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | 2026-08-03 | 0.4        | フロントマターメタデータ（DES-008）の追加に伴い、転記フェーズを反映。§1 概要と §2.2 依存方向規範を「script 層の転記 → 残りを AI 層が充填」の 2 段へ改め、`fm_core.py` を独立系統の共通ロジックとして明記。§2.1 レイヤ図へ `frontmatter/` 系統を追加し、§4.1 に `frontmatter/` 配下 4 件のモジュール表と CLI オプション表を追記。§6.1 のシーケンスへ `fm_to_pending.py` の転記経路を追記し、§6.6 の再開判定を転記を含む順序へ更新。§9.3 の単体モードシーケンスにも同じ転記経路を追記し、§10 の `index-docs` 責務と `write-frontmatter` SKILL の行を追加。あわせて `formats/toc_format.md` の Language Rule を本文追従へ改訂（DES-008 §4.4）                                                                                                                                                                                                                                                                                                                                                        |
 | 2026-08-03 | 0.5        | AI 抽出結果の書き戻し候補（DES-008 §8.2）の受け渡し経路を反映。§8.1 のスキーマ例と §8.2 の enum 定義表へ `merge_toc.py` 固有フィールド `ai_extracted_paths` を追記し、報告専用であること・`status: ok` 時のみ出力すること・`--delete-only` では常に空配列であることを明記。§10 の `index-docs` は merge 完了後に候補を提示し、承認された対象のみを `write-frontmatter` へ `--paths-json` で引き渡す                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 2026-08-04 | 1.0        | **上位層との契約を壊していた不具合を修復した**（§4.1.1 に「呼び出し元は 2 種類ある」を新設・§4.1 の CLI 表・§13 のテスト）。0.7 のラッパー化で対象指定を `--dirs` / `--exclude` のみとし、`--dirs-json` / `--exclude-json` を落としたため、これらを渡して **index-docs を 1 回だけ呼ぶ** forge の `update-db-rules` / `update-db-specs` が `unrecognized arguments` で失敗していた。上位層は再実行も引数の組み替えもしないため、索引が動かないまま理由も分からない状態になる。「入口の数を絞る」ことと「受け付ける引数の形を絞る」ことは別であり、後者は呼び出し元を壊すという教訓を規定として残した                                                                                                                                                                                                                                                                                                                                                                                              |
 | 2026-08-04 | 0.9        | Codex レビュー round 3（🟡 major 1 件）を反映。転記モジュールの読み込み失敗の捕捉を `ImportError` から `Exception` 全体へ広げた（§4.1.1 / §13）。構文エラーは `SyntaxError` であり `ImportError` ではないため、捕まえ損ねると traceback で終了し §8.1 の「stdout に単一 JSON」契約を破る。0.8 の時点では「破損が露見する方向なので放置」と判断していたが、silent success を避けることと CLI 契約を満たすことは別の要求であり、後者を落としていた。回帰テストを 3 通り（欠落 / 構文エラー / 依存の破損）へ拡張し、stdout が単一 JSON で stderr に traceback が出ないことを固定した                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | 2026-08-04 | 0.8        | Codex レビュー（🟡 major 2 件）を反映。①転記の「撤回」と「破損」を区別し、`frontmatter/` があるのに転記モジュールを読み込めない場合は `action: error`（`READ_ERROR`）とした（§4.1.1）。`ImportError` の捕捉だけでは破損を撤回と同一視していた。**この判断の根拠は「誤った ToC が出ること」ではない**——破損時も AI 抽出へフォールバックするため `toc.yaml` の内容は正しく、失われるのは転記による高速化だけである。防ぐのは「配布物が壊れたまま性能劣化が黙って続くこと」であり、可用性（AI 抽出では索引できるのに止まる）とのトレードオフを取ったうえで、配布物の部分破損は放置してよい状態ではないと判断した。②充填エラーの再試行を claim/lease に乗せた（ADR-006 追補 2）。`error_pending` をそのまま投入すると `claim_entries` が拒否するため claim が効かず、同じコマンドの再実行で二重投入が起きていた。`toc_store.reset_error_entries()` / `--reset-error` を追加し、error 状態を解除してから通常の claim 経路へ合流させる。§4.1 の CLI 表に `toc_store.py` の行を追加し §13 にテストを追記 |
 | 2026-08-04 | 0.7        | 索引パイプラインのラッパー `index_docs.py` を追加した（§4.1 モジュール一覧・§4.1.1 新節・§2.1 レイヤ図・§10 の `index-docs` 責務・§13 のテスト設計）。個々の処理は script 化されていたが **script 間の配管が AI に残っており**、1 回の索引で AI が 15 回以上のコマンドを手で組み立て、各段の JSON から次の引数へフィールドを転記していた。とくに連続ディスパッチの空きスロット計算は ADR-006 が明示的に警告している計算であり、AI に委ねる根拠がなかった。AI が呼ぶ入口を 1 本に集約し、残す責務を「Agent の起動」と「判断」のみとした。コア script の CLI は残すが SKILL からは呼ばないことを規約とした。ウィンドウ幅等のチューニング値は CLI に出さない                                                                                                                                                                                                                                                                                                                                         |

--- a/docs/specs/frontmatter/design/DES-008_frontmatter_metadata.md
+++ b/docs/specs/frontmatter/design/DES-008_frontmatter_metadata.md
@@ -1,7 +1,7 @@
 ---
 type: doc-advisor
 title: DES-008 doc-advisor Frontmatter Design
-purpose: Defines the design for embedding ToC metadata as frontmatter so index-docs can skip toc-updater cold reads, covering the schema, trust predicate, and script layout.
+purpose: Defines the design for embedding ToC metadata as frontmatter so index-docs can skip toc-updater cold reads, covering the schema, trust predicate, script layout, and the write SKILL argument contract.
 content_details:
   - Why OKF v0.1 compliance was rejected - type works only paired with resource, and tags pulls against the keywords rule
   - Frontmatter schema - the type marker plus the 5 ToC fields plus body_hash
@@ -12,13 +12,14 @@ content_details:
   - Trust predicate - doc-advisor in type, the 5 fields matching the schema, and body_hash matching the body
   - Which validations belong to the write side (values) versus the read side (missing fields, marker, hash)
   - Withdrawal by deleting one directory depends on the indexing side treating its absence as normal
-  - fm_run.py wrapper - plan resolves targets, apply writes and verifies trust so the caller compares nothing
+  - write-frontmatter argument contract - --paths / --dirs / --exclude / --format-command, with fm_run.py plan resolving targets and apply verifying trust
 applicable_tasks:
   - Implementing or modifying fm_core.py / fm_read.py / fm_write.py / fm_to_pending.py / fm_run.py
   - Changing the trust predicate or the frontmatter schema
   - Deciding where body_hash is stamped relative to formatting
   - Deciding whether a validation belongs to the write side or the read side
   - "Reviewing whether the type union update preserves other tools' markers"
+  - Changing the write-frontmatter SKILL arguments
   - Adding frontmatter to existing documents via write-frontmatter
   - Designing the write-back of AI extraction results
 keywords:
@@ -32,7 +33,7 @@ keywords:
   - OKF
   - extracted_by
   - "--format-command"
-body_hash: sha256:69d6336546a9c696811811bb49b5b64bf2b1265c9e4ab81100eaa9436f780424
+body_hash: sha256:cafb8f2fd2560d0fa3f0750b5aae139f8ddef726c3194badd82c16fe08791496
 ---
 
 # DES-008: doc-advisor フロントマター設計書
@@ -427,6 +428,7 @@ fm_write.py --entries-json '[{"path": "docs/a.md", "metadata": {...}}]' [--forma
 - `fm_write.py`: 未知キー（`name` / `description` 等）が保持されること、および **`type` が和集合更新されること**（`temporary-feature-requirement` のみを持つ文書へ書き込むと `[temporary-feature-requirement, doc-advisor]` になり、既存値が消えない）
 - **値域検証の一方向包含（§6.2）**: 書き込み側が受理した metadata を書き込んだ結果に、読み取り側の**値域**判定が違反を返さないこと。あわせて値域違反の各種（文字数超過・件数超過・空・型不一致・配列内の空要素）で **対象ファイルのバイト列が 1 バイトも変わらない**ことを固定する。`changed` の値は script の自己申告であり、書かれていないことの証明にならないため、実ファイルを読み比べる。上限ちょうど（`purpose` 200 文字・配列 10 件）が違反にならない境界も固定する
 - **部分指定が欠落を理由に弾かれないこと**: 一部のフィールドのみを渡した書き込みが成功し、渡さなかったフィールドの既存値が保持されること（§6.2 の非対称が実際に成立していることの確認）
+- **引数契約（§8.1）**: `fm_run.py` が契約の各引数を受け付けること、および `write-frontmatter/SKILL.md` が契約の各引数を**記載していること**。SKILL.md は全面書き換えの対象になる配布物であり、記載が消えると AI がその形で呼べなくなる（DES-005 §10.1 の事故と同種）
 - **ラッパー（`fm_run.py`）**: `plan` が信頼できる文書を `targets` から外すこと・`doc-advisor` の標識を持つのに信頼できない文書を `warnings` に載せること・原本を 1 バイトも変更しないこと。`apply` が書き込み後の `trust` を返すこと・`trusted` が `written` に届かないとき `status: partial` になること・`--entries-file` の不正（不在・壊れた JSON・未知キー）が `error` になること
 
 ### 6.5 書き込み SKILL が呼ぶラッパー `fm_run.py`
@@ -517,6 +519,21 @@ sequenceDiagram
 
 1 度コールドリードを払えば結果は文書内に残り、git を通じて全クローンに伝播するため、以降は誰がどこで索引しても転記のみで済む（§7.2 のクローン境界の議論による）。
 
+#### `write-frontmatter` の引数契約 [MANDATORY]
+
+**SKILL の引数は公開インターフェースであり、その正本は本設計書に置く。** 理由と変更規約は DES-005 §10.1 に規定する（SKILL.md を唯一の正本にすると、全面書き換えで契約が消えても突き合わせる相手がいない）。
+
+| 引数                           | 主な呼び出し元        | 備考                                                      |
+| ------------------------------ | --------------------- | --------------------------------------------------------- |
+| `--paths <path>...`            | `index-docs` / 利用者 | 対象ファイル。書き戻し（§8.2）はこの形で引き渡す          |
+| `--dirs <dir>...`              | 利用者                | 対象ディレクトリ。グロブメタ文字可。`--paths` と併用可    |
+| `--exclude <path>...`          | 利用者                | `--dirs` 展開時の追加除外（システム固定除外は常時適用）   |
+| `--format-command '<command>'` | 利用者                | `{file}` が対象パスへ置換される。**未指定なら整形しない** |
+
+**現時点で上位層（forge / anvil）からの呼び出し元は存在しない。** 唯一の呼び出し元は `index-docs` の書き戻し経路であり `--paths` のみを使う。上位層への契約反映は §10.3 のとおり未決であり、**契約が生じた時点で本表と DES-005 §10.1 の「既知の呼び出し元」を同時に更新する**。
+
+JSON 形（`--paths-json` 等）は持たない。上位層の呼び出し元が無く、機械的に配列を渡す必要が生じていないためである。必要になった時点で追加する（追加は既存の呼び出し元を壊さない）。
+
 ### 8.2 AI 抽出結果の書き戻し
 
 `index-docs` が AI 抽出にフォールバックした場合、その結果を原本のフロントマターへ書き戻せばコーパスが自己修復する。ただし**索引処理と同時には行わない**。索引という読み取り操作の副作用で原本に git diff が生じるのは驚きがあるためである。
@@ -574,6 +591,7 @@ forge / anvil の文書作成・編集スキルに「作成時にフロントマ
 | 2026-08-02 | 1.2        | 実装着手前の判断事項を反映。`fm_to_pending.py` に `--work-dir` の一括処理を追加（§6.1 / §6.2）、スキーマ規約のテストを一方向の包含関係へ変更（§6.4）、§7.1 の無改造範囲を JSON 出力への項目追加を除く形へ限定して §8.2 との矛盾を解消、書き込み SKILL の形態と適用対象を決定（§10）                                                                                                                                                                                                                                                                                                                                                                 |
 | 2026-08-02 | 1.3        | `fm_read.py` の走査モードを廃止し、対象を `--paths-json` で受け取る形へ変更（§6.1 / §6.2）。§10.2 の配布物除外を script の機能仕様から運用方針へ位置づけ直した。配布先に存在しないパスの判定を配布物へ焼き込むことになり、対象を上位層が決める `index-docs --paths-json` の思想とも矛盾するため                                                                                                                                                                                                                                                                                                                                                     |
 | 2026-08-02 | 1.4        | `fm_to_pending.py` の処理単位を `--work-dir` のみへ限定し、1 ファイル単位（`--out`）を廃した（§6.1 / §6.2）。呼び出し元は転記フェーズの一括処理だけであり、使われない経路を実装しないため。あわせて pending の列挙規則を `merge_toc.py` と揃えること、および書式を `write_pending.py` の出力とバイト一致させることを §6.1 に明記                                                                                                                                                                                                                                                                                                                    |
+| 2026-08-04 | 1.9        | **`write-frontmatter` の引数契約を §8.1 に規定した**（DES-005 §10.1 と対）。従来は引数仕様が SKILL.md にしか存在せず、SKILL.md は方式変更のたびに全面書き換えの対象になるため、契約が消えても突き合わせる相手が無かった（`index-docs` で実際に消えて上位層が失敗した）。あわせて現時点で上位層からの呼び出し元が存在せず唯一の呼び出し元が `index-docs` の書き戻し（`--paths` のみ）であることを明記し、契約が生じた時点で本表と DES-005 §10.1 を同時に更新する義務を課した。JSON 形を持たない判断（必要が生じていない。追加は既存の呼び出し元を壊さないため後からでよい）も記録。§6.4 に引数契約のテストを追加                                     |
 | 2026-08-04 | 1.8        | §6.1 の「1 ディレクトリの削除で戻せる」という主張に、**それがディレクトリ構造だけでは成立せず索引側の実装に依存する**ことを明記した。実装当初は `frontmatter/` の不在で呼び出し元（`index_docs.py`）がクラッシュしており、本節の主張は成立していなかった（現在はテストで固定）。あわせて不在（撤回）と読み込み失敗（破損）が区別されること、破損時も `toc.yaml` の内容は正しく失われるのは高速化だけであることを追記した                                                                                                                                                                                                                            |
 | 2026-08-04 | 1.7        | 書き込み SKILL が呼ぶラッパー `fm_run.py` を追加した（§6.1 の配置図・§6.2 の責務表・§6.5 新節・§6.4 のテスト規定）。`fm_read` / `fm_write` の間の受け渡しが AI に残っており、`paths` の組み替え・`trust` を見た対象の絞り込み・`--entries-json` の argv 組み立て・書き込み後の件数比較を AI が手でやっていた。`plan` / `apply` の 2 サブコマンドに畳み、AI に残す責務を「メタデータの内容を作ること」と「承認を取ること」だけにした。`apply` が書き込み後の信頼判定まで行うため §6.2 の責務境界を変更した（分離自体は正しかったが、その帰結として SKILL に決定論的な比較が残っていた）。`fm_read` / `fm_write` の CLI は残すが SKILL からは呼ばない |
 | 2026-08-04 | 1.6        | `fm_write.py` に値域検証を課した（§6.2 の新節「値域の検証を書き込み側にも課す」・§6.3 の処理順序へ手順 0 を追加・§6.4 のテスト規定）。当初は「上限の検証は読み取り側の責務」として書き込み側では検証しない設計だったが、**書ける値の集合が信頼される値の集合に収まらず**、script が書いた直後の文書が信頼できない状態が実際に発生した（`purpose` 206 文字）。値域規則の実装を読み取り側と共有し、一方向の包含をテストで固定する。必須フィールドの充足（欠落）は部分更新を許すため書き込み側では検査せず、責務の非対称を §6.2 の表で明示した                                                                                                         |

--- a/plugins/doc-advisor/scripts/index_docs.py
+++ b/plugins/doc-advisor/scripts/index_docs.py
@@ -387,8 +387,80 @@ def _prepare_argv(args, key):
     return argv
 
 
+# 対象指定の引数（CLI フラグ名 → args の属性名）。`--all` との排他判定と
+# 「対象が明示されたか」の判定を 1 箇所から引くための表。
+TARGET_ARGS = (
+    ("--dirs", "dirs"),
+    ("--dirs-json", "dirs_json"),
+    ("--paths", "paths"),
+    ("--paths-json", "paths_json"),
+    ("--paths-file", "paths_file"),
+)
+
+
+def _explicit_target_flags(args):
+    """明示された対象指定のフラグ名を返す（`--all` との排他判定と報告に使う）。"""
+    return [flag for flag, attr in TARGET_ARGS if getattr(args, attr, None)]
+
+
+def _has_explicit_target(args):
+    """対象が明示されているか（偽なら単体モードとして prepare が走査する）。"""
+    return bool(_explicit_target_flags(args))
+
+
+def _merge_list_arg(repeated, json_form, json_flag):
+    """繰り返し指定（nargs）と JSON 配列指定を 1 つの list へ揃える。
+
+    同じ対象を 2 通りで受け取るのは、**呼び出し元が 2 種類ある**ためである。
+
+    - 人間・AI が手で打つ経路 — `--dirs docs/rules/ docs/specs/` の方が短く、
+      引用符のエスケープも要らない
+    - 上位層（forge 等）が機械的に渡す経路 — 自身の設定から解決した配列を
+      そのまま `--dirs-json '[...]'` で渡す。文字列を組み立て直させない
+      （どの設定から解決するかは上位層の関心であり、本 script は知らない）
+
+    両方を受け取り、指定されていれば連結する（併用可）。上位層の既存の呼び出しを
+    壊さないための互換であり、増やしてよいオプションの例外ではない。
+
+    Args:
+        repeated: nargs で受けた list（None 可）
+        json_form: JSON 配列の文字列（None 可）
+        json_flag: エラーメッセージに出すフラグ名
+
+    Returns:
+        list: 連結した結果（どちらも無ければ空 list）
+
+    Raises:
+        WrapperError: json_form が JSON 配列として解析できない
+    """
+    merged = list(repeated or [])
+    if not json_form:
+        return merged
+    try:
+        parsed = json.loads(json_form)
+    except ValueError as e:
+        raise WrapperError(
+            f"{json_flag} を JSON として解析できません: {e}",
+            ErrorCode.INVALID_PATH,
+        )
+    if not isinstance(parsed, list):
+        raise WrapperError(
+            f"{json_flag} は JSON 配列である必要があります",
+            ErrorCode.INVALID_PATH,
+        )
+    for item in parsed:
+        if not isinstance(item, str) or not item.strip():
+            raise WrapperError(
+                f"{json_flag} の要素は非空の文字列である必要があります",
+                ErrorCode.INVALID_PATH,
+            )
+    merged.extend(parsed)
+    return merged
+
+
 def _expand_targets(args):
-    """`--dirs` / `--paths` / `--paths-file` を prepare 用の paths へ揃える。
+    """対象指定（`--dirs` / `--paths` / それらの JSON 形 / `--paths-file`）を
+    prepare 用の paths へ揃える。
 
     ディレクトリ展開は expand_dirs の責務であり、ラッパーは列挙を自分で書かない。
 
@@ -397,39 +469,28 @@ def _expand_targets(args):
             paths が None のときは単体モード（prepare が自分で走査する）
 
     Raises:
-        WrapperError: expand_dirs が error を返した
+        WrapperError: expand_dirs が error を返した / JSON 形の引数が不正
     """
-    if not args.dirs and not args.paths and not args.paths_json and not args.paths_file:
+    if not _has_explicit_target(args):
         return None, [], []
 
     if args.paths_file:
         # paths-file はそのまま prepare へ渡す（展開の対象ではない）
         return None, [], []
 
+    all_dirs = _merge_list_arg(args.dirs, args.dirs_json, "--dirs-json")
+    explicit_paths = _merge_list_arg(args.paths, args.paths_json, "--paths-json")
+    all_exclude = _merge_list_arg(args.exclude, args.exclude_json, "--exclude-json")
+
     argv = []
-    if args.dirs:
-        argv.extend(["--dirs-json", json.dumps(args.dirs)])
-    explicit_paths = list(args.paths or [])
-    if args.paths_json:
-        try:
-            parsed = json.loads(args.paths_json)
-        except ValueError as e:
-            raise WrapperError(
-                f"--paths-json を JSON として解析できません: {e}",
-                ErrorCode.INVALID_PATH,
-            )
-        if not isinstance(parsed, list):
-            raise WrapperError(
-                "--paths-json は JSON 配列である必要があります",
-                ErrorCode.INVALID_PATH,
-            )
-        explicit_paths.extend(parsed)
+    if all_dirs:
+        argv.extend(["--dirs-json", json.dumps(all_dirs)])
     if explicit_paths:
         argv.extend(["--paths-json", json.dumps(explicit_paths)])
-    if args.exclude:
-        argv.extend(["--exclude-json", json.dumps(args.exclude)])
+    if all_exclude:
+        argv.extend(["--exclude-json", json.dumps(all_exclude)])
 
-    if not args.dirs:
+    if not all_dirs:
         # 展開するディレクトリが無い＝明示 paths のみ。expand_dirs を通す必要がない
         return explicit_paths, [], []
 
@@ -530,12 +591,7 @@ def run(args):
     # 0. 矛盾する対象指定を弾く。--all は project root 以下を自分で走査するため、
     #    ディレクトリ・パスの指定と併用しても片方が黙って無視される。
     #    どちらを優先すべきか推定せずエラーにする。
-    explicit_targets = [
-        name for name, value in (
-            ("--dirs", args.dirs), ("--paths", args.paths),
-            ("--paths-json", args.paths_json), ("--paths-file", args.paths_file),
-        ) if value
-    ]
+    explicit_targets = _explicit_target_flags(args)
     if args.all and explicit_targets:
         raise WrapperError(
             "--all は project root 以下の全 Markdown を対象にするため "
@@ -881,6 +937,10 @@ def parse_args(argv=None):
         help="索引するディレクトリ（複数指定可。グロブメタ文字可）",
     )
     parser.add_argument(
+        "--dirs-json", dest="dirs_json",
+        help="dirs の JSON 配列（上位層からの機械的な受け渡し用。--dirs と併用可）",
+    )
+    parser.add_argument(
         "--paths", nargs="+", metavar="PATH",
         help="索引する Markdown ファイル（複数指定可。--dirs と併用可）",
     )
@@ -895,6 +955,10 @@ def parse_args(argv=None):
     parser.add_argument(
         "--exclude", nargs="+", metavar="PATH",
         help="--dirs 展開時に除外するパス・ディレクトリ",
+    )
+    parser.add_argument(
+        "--exclude-json", dest="exclude_json",
+        help="exclude の JSON 配列（上位層からの機械的な受け渡し用。--exclude と併用可）",
     )
     parser.add_argument(
         "--allow-external", dest="allow_external", nargs="*", metavar="SYMLINK",

--- a/plugins/doc-advisor/skills/index-docs/SKILL.md
+++ b/plugins/doc-advisor/skills/index-docs/SKILL.md
@@ -39,19 +39,26 @@ AI が担うのは次の 2 つだけである。
 /doc-advisor:index-docs --key <key> --dirs 'docs/specs/**/design/'   # グロブ可
 /doc-advisor:index-docs --key <key> --dirs docs/ --exclude docs/draft/
 /doc-advisor:index-docs --key <key> --paths docs/a.md docs/b.md
-/doc-advisor:index-docs --key <key> --paths-json '["docs/a.md"]'     # 上位層からの機械的な受け渡し
 /doc-advisor:index-docs --all
+
+# 上位層（forge 等）が機械的に渡す形
+/doc-advisor:index-docs --key <key> --dirs-json '["docs/rules/"]' --exclude-json '["docs/rules/draft/"]'
+/doc-advisor:index-docs --key <key> --paths-json '["docs/a.md"]'
 ```
 
-| Argument               | Description                                                                                             |
-| ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| `--key <key>`          | 対象 ToC の opaque key（上位層が決定）。`all` は予約語のため任意指定不可                                |
-| `--dirs <dir>...`      | 索引するディレクトリ（複数指定可）。グロブメタ文字（`*` `?` `[`）を含めるとパターン展開                 |
-| `--paths <path>...`    | 索引する Markdown ファイル（複数指定可。`--dirs` と併用可）                                             |
-| `--paths-json '[...]'` | paths の JSON 配列（上位層が機械的に渡す場合）                                                          |
-| `--paths-file <path>`  | paths 配列を含む JSON ファイル                                                                          |
-| `--exclude <path>...`  | `--dirs` 展開時に除外するパス・ディレクトリ（システム固定除外は常時適用）                               |
-| `--all`                | 単体モード。予約 key `all` に解決し project root 以下の全 Markdown を対象にする。対象指定と併用できない |
+| Argument                 | Description                                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `--key <key>`            | 対象 ToC の opaque key（上位層が決定）。`all` は予約語のため任意指定不可                                |
+| `--dirs <dir>...`        | 索引するディレクトリ（複数指定可）。グロブメタ文字（`*` `?` `[`）を含めるとパターン展開                 |
+| `--dirs-json '[...]'`    | dirs の JSON 配列（**上位層が機械的に渡す形**。`--dirs` と併用可）                                      |
+| `--paths <path>...`      | 索引する Markdown ファイル（複数指定可。`--dirs` と併用可）                                             |
+| `--paths-json '[...]'`   | paths の JSON 配列（**上位層が機械的に渡す形**）                                                        |
+| `--paths-file <path>`    | paths 配列を含む JSON ファイル                                                                          |
+| `--exclude <path>...`    | `--dirs` 展開時に除外するパス・ディレクトリ（システム固定除外は常時適用）                               |
+| `--exclude-json '[...]'` | exclude の JSON 配列（**上位層が機械的に渡す形**。`--exclude` と併用可）                                |
+| `--all`                  | 単体モード。予約 key `all` に解決し project root 以下の全 Markdown を対象にする。対象指定と併用できない |
+
+> **JSON 形をそのまま渡す [MANDATORY]**: 上位層（forge の `update-db-rules` / `update-db-specs` 等）は `.doc_structure.yaml` から解決した配列を `--dirs-json` / `--exclude-json` で渡し、**本 SKILL を 1 回だけ呼ぶ**（再実行や引数の組み替えをしない）。受け取った JSON 形は**そのまま script へ渡す**こと。`--dirs` へ書き換えたり要素を並べ替えたりしない。script が両形を受け付けて連結する。
 
 > **desired-state の破壊性 [MANDATORY]**: 渡す対象は当該 key の **完全な desired state** である。前回 ToC に存在し今回含まれない path は **削除** される（部分指定すると残りが消える）。上位層の責務である。
 
@@ -72,7 +79,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/index_docs.py --key "{key}" --dirs {dirs}
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/index_docs.py --all
 ```
 
-`$ARGUMENTS` から `--key` / `--dirs` / `--paths` / `--paths-json` / `--paths-file` / `--exclude` / `--all` を解釈して渡す。引数が空なら `--all` として扱う。
+`$ARGUMENTS` から `--key` / `--dirs` / `--dirs-json` / `--paths` / `--paths-json` / `--paths-file` / `--exclude` / `--exclude-json` / `--all` を解釈して渡す。引数が空なら `--all` として扱う。**JSON 形（`--dirs-json` 等）は形を変えずそのまま渡す**（前掲の [MANDATORY]）。
 
 **初回と再開を区別しない [MANDATORY]**。状態は `.toc_work/` が持ち、script が今どの段階かを判定する。**Agent の完了通知を受けたら、同じコマンドをそのまま再実行する**。前回セッションの続きであっても、compaction を越えていても、同じコマンドで再開できる。
 

--- a/tests/integration/test_index_docs_wrapper.py
+++ b/tests/integration/test_index_docs_wrapper.py
@@ -622,6 +622,84 @@ class TestFillErrorIsNotSilentlyMerged(WrapperTestBase):
         self.assertIn('claimed_at', entry_text, 'claim のスタンプが付いている')
 
 
+class TestUpperLayerContract(WrapperTestBase):
+    """上位層（forge 等）が渡す JSON 形の引数を受けること
+
+    forge の update-db-specs / update-db-rules は `.doc_structure.yaml` から解決した
+    配列を `--dirs-json` / `--exclude-json` で渡し、index-docs を **1 回だけ** 呼ぶ
+    （再実行や引数の組み替えをしない）。したがってこの形を受けられなくなると
+    **上位層からの索引が動かなくなり、上位層には理由が分からない**。
+
+    人間・AI が手で打つ `--dirs` / `--exclude` と、機械的に渡す JSON 形の両方を
+    受けるのは、呼び出し元が 2 種類あるためである（オプションを増やしてよい
+    という例外ではない）。
+    """
+
+    def test_dirs_json_is_accepted_as_forge_passes_it(self):
+        for i in range(1, 4):
+            self._write_md(f'docs/d{i}.md')
+
+        payload = self._index('--key', 'rules', '--dirs-json', json.dumps(['docs/']))
+
+        self.assertEqual(payload['action'], 'dispatch')
+        dispatched = [
+            e for agent in payload['agents'] for e in agent['entry_files']
+        ]
+        self.assertEqual(len(dispatched), 3)
+
+    def test_exclude_json_is_accepted_and_applied(self):
+        self._write_md('docs/keep.md')
+        self._write_md('docs/drop.md')
+
+        payload = self._index(
+            '--key', 'rules',
+            '--dirs-json', json.dumps(['docs/']),
+            '--exclude-json', json.dumps(['docs/drop.md']),
+        )
+
+        self.assertEqual(payload['action'], 'dispatch')
+        dispatched = [
+            e for agent in payload['agents'] for e in agent['entry_files']
+        ]
+        self.assertEqual(len(dispatched), 1, 'exclude-json が効いていない')
+
+    def test_repeated_and_json_forms_are_merged(self):
+        self._write_md('a/one.md')
+        self._write_md('b/two.md')
+
+        payload = self._index(
+            '--key', 'rules', '--dirs', 'a/', '--dirs-json', json.dumps(['b/']),
+        )
+
+        self.assertEqual(payload['action'], 'dispatch')
+        dispatched = [
+            e for agent in payload['agents'] for e in agent['entry_files']
+        ]
+        self.assertEqual(len(dispatched), 2, '併用時に連結されていない')
+
+    def test_paths_file_is_accepted(self):
+        self._write_md('docs/a.md')
+        paths_file = self.project_root / 'paths.json'
+        paths_file.write_text(json.dumps(['docs/a.md']), encoding='utf-8')
+
+        payload = self._index('--key', 'rules', '--paths-file', 'paths.json')
+
+        self.assertEqual(payload['action'], 'dispatch')
+
+    def test_malformed_dirs_json_is_rejected(self):
+        payload = self._index('--key', 'rules', '--dirs-json', '{not json')
+
+        self.assertEqual(payload['action'], 'error')
+        self.assertEqual(payload['error_code'], 'INVALID_PATH')
+
+    def test_dirs_json_must_be_an_array_of_non_empty_strings(self):
+        for bad in ('{"a": 1}', json.dumps(['ok', '']), json.dumps([1, 2])):
+            with self.subTest(bad=bad):
+                payload = self._index('--key', 'rules', '--dirs-json', bad)
+                self.assertEqual(payload['action'], 'error')
+                self.assertEqual(payload['error_code'], 'INVALID_PATH')
+
+
 class TestArgumentContract(WrapperTestBase):
     """引数の矛盾・不正が error として返ること"""
 
@@ -632,6 +710,21 @@ class TestArgumentContract(WrapperTestBase):
 
         self.assertEqual(payload['action'], 'error')
         self.assertEqual(payload['error_code'], 'UNSUPPORTED_ARG')
+
+    def test_all_cannot_be_combined_with_json_form_targets(self):
+        """JSON 形の対象指定も `--all` との併用を拒否し、フラグ名を報告すること。"""
+        self._write_md('docs/a.md')
+
+        for flag, value in (('--dirs-json', json.dumps(['docs/'])),
+                            ('--paths-json', json.dumps(['docs/a.md']))):
+            with self.subTest(flag=flag):
+                payload = self._index('--all', flag, value)
+                self.assertEqual(payload['action'], 'error')
+                self.assertEqual(payload['error_code'], 'UNSUPPORTED_ARG')
+                self.assertIn(
+                    flag, payload['message'],
+                    'どの引数が併用されたかを報告していない',
+                )
 
     def test_reserved_key_is_rejected(self):
         payload = self._index('--key', 'all', '--dirs', 'docs/')

--- a/tests/skills/test_skill_argument_contract.py
+++ b/tests/skills/test_skill_argument_contract.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+SKILL の引数契約テスト（DES-005 §10.1 / DES-008 §8.1）
+
+SKILL の引数は上位層との公開インターフェースである。正本は設計書に置くが、
+配布物（SKILL.md）と実装（script の argparse）がその契約を実際に満たしていることは
+テストで固定する。
+
+このテストが存在する理由は実際の事故である。ラッパー化の際に `index-docs` から
+`--dirs-json` / `--exclude-json` が落ち、forge の update-db-rules / update-db-specs /
+query-db-rules / query-db-specs が `unrecognized arguments` で失敗した。上位層は
+引数を組み替えず再試行もしないため、索引が動かないまま上位層には理由が分からない
+状態になる。当時 SKILL.md が引数仕様の唯一の正本であり、全面書き換えで契約が
+消えても突き合わせる相手が無かった。
+
+したがって検証するのは 2 点である:
+
+1. script が契約の引数を**受け付ける**こと（実装が壊れていない）
+2. SKILL.md が契約の引数を**記載している**こと（AI がその形で呼べる／消えたら落ちる）
+
+引数の**追加**は既存の呼び出し元を壊さないため、このテストは網羅性を要求しない
+（契約分が揃っていれば追加分は自由）。削除・改名を検出することが目的である。
+
+実行:
+  python3 -m unittest tests.skills.test_skill_argument_contract -v
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = REPO_ROOT / 'plugins' / 'doc-advisor'
+SCRIPTS_DIR = PLUGIN_ROOT / 'scripts'
+
+# DES-005 §10.1: index-docs が受け付けなければならない引数
+INDEX_DOCS_CONTRACT = [
+    '--key',
+    '--dirs',
+    '--dirs-json',
+    '--paths',
+    '--paths-json',
+    '--paths-file',
+    '--exclude',
+    '--exclude-json',
+    '--all',
+    '--allow-external',
+    '--on-fill-error',
+]
+
+# DES-008 §8.1: write-frontmatter が受け付けなければならない引数
+WRITE_FRONTMATTER_CONTRACT = [
+    '--paths',
+    '--dirs',
+    '--exclude',
+    '--format-command',
+]
+
+# DES-009 / DES-005 §10.1
+CHECK_TOC_CONTRACT = ['--key', '--all', '--max-age']
+
+
+def _load_module(name, path):
+    """script を単体モジュールとして読み込む（パッケージ化されていないため）。"""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestIndexDocsArgumentContract(unittest.TestCase):
+    """index-docs: script 実装と SKILL.md の双方が契約を満たすこと。"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load_module('index_docs_contract',
+                                  SCRIPTS_DIR / 'index_docs.py')
+        cls.skill_text = (PLUGIN_ROOT / 'skills' / 'index-docs' / 'SKILL.md').read_text(
+            encoding='utf-8')
+
+    # 契約の各引数を単体で通すための最小 argv。unrecognized arguments を
+    # 検出するのが目的であり、値の妥当性は各引数のテストが別途担う。
+    ARGV_FOR_FLAG = {
+        '--key': ['--key', 'k'],
+        '--all': ['--all'],
+        '--on-fill-error': ['--key', 'k', '--on-fill-error', 'merge'],
+        '--allow-external': ['--key', 'k', '--allow-external'],
+    }
+
+    def test_script_accepts_contract_flags(self):
+        for flag in INDEX_DOCS_CONTRACT:
+            argv = self.ARGV_FOR_FLAG.get(flag, ['--key', 'k', flag, 'x'])
+            try:
+                self.module.parse_args(argv)
+            except SystemExit as e:
+                self.fail(f'index_docs.py が契約の引数 {flag} を受け付けない'
+                          f'（SystemExit {e.code}）。DES-005 §10.1。'
+                          '削除・改名は上位層の呼び出しを壊すため承認が必要')
+
+    def test_skill_documents_contract_flags(self):
+        # assertIn は失敗時に SKILL.md 全文をダンプするため assertTrue を使う。
+        for flag in INDEX_DOCS_CONTRACT:
+            self.assertTrue(
+                flag in self.skill_text,
+                f'index-docs/SKILL.md が契約の引数 {flag} を記載していない'
+                '（記載が消えると AI がその形で呼べず、上位層の呼び出しが失敗する）')
+
+    def test_skill_forbids_rewriting_json_form(self):
+        """上位層が渡した JSON 形をそのまま渡す規定が残っていること。"""
+        self.assertTrue('--dirs-json' in self.skill_text,
+                        'index-docs/SKILL.md に --dirs-json の記載がない')
+        self.assertTrue('そのまま' in self.skill_text,
+                        '受け取った JSON 形をそのまま渡す規定が SKILL.md から消えている')
+
+
+class TestWriteFrontmatterArgumentContract(unittest.TestCase):
+    """write-frontmatter: 引数契約（DES-008 §8.1）。"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.skill_path = PLUGIN_ROOT / 'skills' / 'write-frontmatter' / 'SKILL.md'
+        cls.skill_text = cls.skill_path.read_text(encoding='utf-8')
+
+    def test_skill_documents_contract_flags(self):
+        for flag in WRITE_FRONTMATTER_CONTRACT:
+            self.assertTrue(
+                flag in self.skill_text,
+                f'write-frontmatter/SKILL.md が契約の引数 {flag} を記載していない')
+
+    def test_wrapper_accepts_contract_flags(self):
+        """fm_run.py が契約の引数を受け付けること（サブコマンド構成のため実行で確認）。"""
+        module = _load_module('fm_run_contract',
+                              SCRIPTS_DIR / 'frontmatter' / 'fm_run.py')
+        for argv in (
+            ['plan', '--paths', 'docs/a.md'],
+            ['plan', '--dirs', 'docs/'],
+            ['plan', '--dirs', 'docs/', '--exclude', 'docs/draft/'],
+            ['apply', '--entries-json', '[]', '--format-command', 'x {file}'],
+        ):
+            try:
+                module.parse_args(argv)
+            except SystemExit as e:
+                self.fail(f'fm_run.py が {argv} を受け付けない（SystemExit {e.code}）'
+                          '。DES-008 §8.1')
+
+
+class TestCheckTocArgumentContract(unittest.TestCase):
+    """check-toc: 引数契約（DES-009）。列挙外の引数は受け取らない規定がある。"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.skill_text = (PLUGIN_ROOT / 'skills' / 'check-toc' / 'SKILL.md').read_text(
+            encoding='utf-8')
+
+    def test_skill_documents_contract_flags(self):
+        for flag in CHECK_TOC_CONTRACT:
+            self.assertTrue(
+                flag in self.skill_text,
+                f'check-toc/SKILL.md が契約の引数 {flag} を記載していない')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 何が壊れていたか

ラッパー化（#38）で `index-docs` の対象指定を `--dirs` / `--exclude` のみとし、`--dirs-json` / `--exclude-json` を落としていた。

forge の `update-db-rules` / `update-db-specs` / `query-db-rules` / `query-db-specs` は、自身の設定から解決した配列を `--dirs-json` で渡し **index-docs を 1 回だけ**呼ぶ。上位層は再実行も引数の組み替えもしないため、`unrecognized arguments` で **索引が動かないまま、上位層には理由が分からない**状態になっていた。

`develop` に入っているのはこの壊れた状態である。

## 直したこと

### 1. 引数の復旧（`2ef14d1`）

`--dirs-json` / `--exclude-json` / `--paths-json` / `--paths-file` を受け、繰り返し指定形（`--dirs` 等）と併用したときは連結する。不正な JSON・配列でない値・空文字列を含む配列は `INVALID_PATH` で拒否する。

入口の数を絞ることと、受け付ける引数の形を絞ることは別である。前者は AI の負担を減らすが、**後者は呼び出し元を壊す**。

### 2. 引数契約の正本を設計書へ移した（`870d700`）

根本原因は「呼び出し元を確認しなかった」だけではない。**引数仕様の唯一の正本が SKILL.md（＝全面書き換えの対象そのもの）だった**ため、書き換えで契約が消えても突き合わせる相手がいなかった。

- **DES-005 §10.1 新設** — `index-docs` / `query-docs` / `check-toc` の引数契約、変更規約（追加は自由 / 削除・改名は横断 grep と承認 / 受け付ける形を減らすのは削除と同じ扱い）、既知の呼び出し元
- **DES-008 §8.1** — `write-frontmatter` の引数契約。上位層の呼び出し元が現時点で存在しないこと、生じた時点で両設計書を同時更新する義務
- **DES-005 §4.1 の欠落を補完** — `expand_dirs.py` の行が無く、**`--dirs-json` の出所が設計書上どこにも無かった**。`prepare_toc.py` の `--allow-external-json` も追加
- **古くなっていた記述を修正** — §10 が「`write-frontmatter` へ `--paths-json` で引き渡す」のままだった（実際は `--paths`）

### 3. 消失を検出するテスト（`870d700`）

`tests/skills/test_skill_argument_contract.py`（6 件）。script が契約引数を受理すること**と** SKILL.md がそれを記載していることの両方を固定する。実装が受理するだけでは、SKILL.md から記載が消えれば AI はその形で呼べない。

**壊れていた時点（`31a580a`）の worktree で走らせ、3 件落ちることを確認して導入した。**

### 4. 手順面の再発防止（`730bbd3`）

`docs/rules/implementation_guidelines.md` に「配布インターフェースを壊す前に呼び出し元を確認する」を追加（横断 grep / `Write` 全面上書き後の `git diff` / 計画への名指し）。機械的検証を持つ 2〜3 の方が強いことは承知のうえで、手順として書ける範囲を残した。

## 検証

- `python3 -m unittest discover -s tests -p 'test_*.py'` — **798 件 OK**（+15 件）
- `dprint check` — OK
- 本文を編集した 3 文書のフロントマターを `fm_run.py` で更新（`body_hash` 不一致の解消）。DES-005 の `purpose` は値域検証が 204 文字で書き込み前に弾いたため短縮した

## 含まないもの

external_symlink の default-deny 撤去は REQ-001 NFR-N06 の変更を伴う挙動変更のため、別 PR とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)